### PR TITLE
feat(compose): production-ready docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,31 @@ DS_MCP_TRANSPORT=http
 # HTTP server bind address (0.0.0.0 allows external access)
 MCP_HOST=0.0.0.0
 
-# HTTP server port
+# Host-side port for the MCP HTTP endpoint.
+# The container always listens on 8001 internally (fixed, matches the
+# Dockerfile HEALTHCHECK). This variable controls only the host-side
+# port mapping in docker-compose.yml.
 MCP_PORT=8001
+
+# ============================================
+# Docker Compose — Image tag (production)
+# ============================================
+# Pin to a specific version (e.g. 0.2.0, 0.2, latest).
+# Used by docker-compose.yml for the prod service.
+IMAGE_TAG=latest
+
+# ============================================
+# Docker Compose — Logging
+# ============================================
+# Per-container log rotation (json-file driver).
+LOG_MAX_SIZE=10m
+LOG_MAX_FILE=3
+
+# ============================================
+# Docker Compose — Resource limits
+# ============================================
+# Adjust to your deployment size. Defaults are conservative.
+CPU_LIMIT=1.0
+MEMORY_LIMIT=512M
+CPU_RESERVATION=0.25
+MEMORY_RESERVATION=128M

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Package metadata**: replaced stale `your-org` placeholder in `pyproject.toml` URLs with `iflytek`
+- **Package metadata**: replaced stale `your-org` placeholder with `iflytek` in `pyproject.toml` and `README*.md` URLs
+- **Setuptools deprecations**: migrated `project.license` from deprecated TOML table `{ text = "Apache-2.0" }` to SPDX string `"Apache-2.0"`; removed `License :: OSI Approved :: Apache Software License` classifier; bumped `setuptools>=68` → `setuptools>=77`
+
+### Docker Compose upgrade (issue #11)
+
+- **`docker-compose.yml`** rewritten as a production-ready reference:
+  - Default `dolphin-mcp-pilot` service pulls from `ghcr.io/iflytek/dolphin-mcp-pilot:${IMAGE_TAG:-latest}`
+  - `dolphin-mcp-pilot-dev` service under `profiles: ["dev"]` builds from local Dockerfile and mounts `./dolphin_mcp_pilot` read-only
+  - Explicit `healthcheck`, `logging` (json-file, `max-size`/`max-file`), and `deploy.resources` (CPU/memory limits + reservations)
+  - Shared config factored via YAML anchors (`x-common`) to keep prod and dev in sync
+  - Container port fixed at 8001 (matches Dockerfile HEALTHCHECK); `MCP_PORT` only controls host-side port mapping
+- **`.env.example`** extended with Compose-tunable variables: `IMAGE_TAG`, `LOG_MAX_SIZE`, `LOG_MAX_FILE`, `CPU_LIMIT`, `MEMORY_LIMIT`, `CPU_RESERVATION`, `MEMORY_RESERVATION`
+- **`README.md` / `README.zh-CN.md`** Option A rewritten as a Docker Compose quickstart (prepare `.env` → `docker compose up` → verify `healthy`); dev mode documented alongside
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This project is designed for **real operations work**:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/your-org/dolphin-mcp-pilot.git
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 
 # 2. Configure environment
@@ -80,7 +80,7 @@ cp .env.example .env
 # or
 start.bat         # Windows
 # or
-docker-compose up -d
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
 ```
 
 ✅ Service will be available at `http://localhost:8001/mcp/` (note the trailing slash)
@@ -89,16 +89,49 @@ docker-compose up -d
 
 ## 📦 Installation Options
 
-### Option A: Docker (Recommended)
+### Option A: Docker Compose (Recommended)
+
+#### A1. Development mode (recommended for now)
+
+Builds from the local Dockerfile and mounts `./dolphin_mcp_pilot` into the container as read-only. Source changes require a container restart (uvicorn is not started with `--reload`):
 
 ```bash
-docker-compose up -d
+# 1. Prepare environment
+cp .env.example .env
+# edit .env — at minimum set DS_URL and DS_TOKEN (see Configuration below)
+
+# 2. Start (dev profile builds locally)
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
+
+# 3. Verify
+docker compose --profile dev ps        # STATUS should show (healthy) after ~10s
+docker compose --profile dev logs -f   # watch startup logs
 ```
+
+The service will be available at `http://localhost:8001/mcp/` (note the trailing slash).
+
+#### A2. Production mode (published image)
+
+> **Note**: The `ghcr.io/iflytek/dolphin-mcp-pilot:latest` image is published automatically when a stable release tag (e.g. `v0.2.0`) is pushed. Until the first release is tagged, use **A1** or **Option B/C** below.
+
+Once a release is available, the prod service pulls from ghcr.io:
+
+```bash
+# Optional: pin to a specific version
+echo "IMAGE_TAG=0.2.0" >> .env
+
+docker compose up -d
+docker compose ps        # STATUS should show (healthy)
+```
+
+See [`docker-compose.yml`](docker-compose.yml) for the full reference (resource limits, log rotation, healthcheck, etc.).
+
+📖 **Detailed deployment guide**: See [DEPLOYMENT.md](DEPLOYMENT.md)
 
 ### Option B: From source
 
 ```bash
-git clone https://github.com/your-org/dolphin-mcp-pilot.git
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 pip install -r requirements.txt
 python -m dolphin_mcp_pilot

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,19 +71,19 @@ This project is designed for **real operations work**:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/your-org/dolphin-mcp-pilot.git
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 
 # 2. Configure environment
 cp .env.example .env
 # Edit .env and set DS_URL + DS_TOKEN (or DS_USER/DS_PASSWORD)
 
-# 3. Start the service
+# 3. 启动服务
 ./start.sh        # Linux/Mac
 # or
 start.bat         # Windows
 # or
-docker-compose up -d
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
 ```
 
 ✅ Service will be available at `http://localhost:8001/mcp/` (note the trailing slash)
@@ -92,16 +92,49 @@ docker-compose up -d
 
 ## 📦 Installation Options
 
-### Option A: Docker (Recommended)
+### Option A: Docker Compose (推荐)
+
+#### A1. 开发模式（当前推荐）
+
+基于本地 Dockerfile 构建，将 `./dolphin_mcp_pilot` 以只读方式挂载进容器。源码修改后需重启容器（uvicorn 未启用 `--reload`）：
 
 ```bash
-docker-compose up -d
+# 1. 准备环境配置
+cp .env.example .env
+# 编辑 .env —— 至少设置 DS_URL 与 DS_TOKEN（详见下方 Configuration）
+
+# 2. 启动服务（dev profile 将本地构建）
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
+
+# 3. 验证
+docker compose --profile dev ps        # STATUS 应在 ~10s 后显示 (healthy)
+docker compose --profile dev logs -f   # 查看启动日志
 ```
+
+服务地址：`http://localhost:8001/mcp/`（注意结尾斜杠）
+
+#### A2. 生产模式（发布镜像）
+
+> **提示**：`ghcr.io/iflytek/dolphin-mcp-pilot:latest` 镜像会在推送稳定 release tag（如 `v0.2.0`）时自动发布。在首个 release 打标前，请使用上方 **A1** 或下方 **Option B/C**。
+
+镜像发布后，prod 服务会直接从 ghcr.io 拉取：
+
+```bash
+# 可选：锁定版本
+echo "IMAGE_TAG=0.2.0" >> .env
+
+docker compose up -d
+docker compose ps        # STATUS 应显示 (healthy)
+```
+
+完整参考（资源限制、日志轮转、健康检查等）见 [`docker-compose.yml`](docker-compose.yml)。
+
+📖 **详细部署指南**：参见 [DEPLOYMENT.md](DEPLOYMENT.md)
 
 ### Option B: From source
 
 ```bash
-git clone https://github.com/your-org/dolphin-mcp-pilot.git
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 pip install -r requirements.txt
 python -m dolphin_mcp_pilot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,91 @@
+# docker-compose.yml — production-ready reference for dolphin-mcp-pilot
+#
+# Quick start:
+#   cp .env.example .env        # edit with your DolphinScheduler credentials
+#   docker compose up -d
+#
+# Development (local Dockerfile + read-only source mount):
+#   docker compose down
+#   docker compose --profile dev up -d dolphin-mcp-pilot-dev
+#
+# The prod service (dolphin-mcp-pilot) pulls from ghcr.io by default.
+# The dev service (dolphin-mcp-pilot-dev) builds from source and mounts
+# ./dolphin_mcp_pilot read-only. Source changes require a container restart
+# (uvicorn is not started with --reload). They share config via YAML
+# anchors (x-common).
+#
+# Port convention: the container always listens on 8001 internally (matching
+# the Dockerfile HEALTHCHECK). The MCP_PORT variable controls the host-side
+# port mapping only.
+
+# ---------------------------------------------------------------------------
+# Shared config (YAML anchors)
+# ---------------------------------------------------------------------------
+x-common: &common
+  restart: unless-stopped
+  env_file:
+    - .env
+  environment: &common-env
+    DS_MCP_TRANSPORT: "${DS_MCP_TRANSPORT:-http}"
+    MCP_HOST: "0.0.0.0"
+    # Container port intentionally fixed at 8001 — the Dockerfile HEALTHCHECK
+    # probes 127.0.0.1:8001 and the prod image exposes 8001. This value
+    # overrides MCP_PORT from env_file so user-customizable host port mapping
+    # does not leak into the container.
+    MCP_PORT: "8001"
+  healthcheck: &common-health
+    # Matches the Dockerfile HEALTHCHECK — stdlib socket probe, no extra deps.
+    test:
+      [
+        "CMD",
+        "python",
+        "-c",
+        "import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', 8001)); s.close()",
+      ]
+    interval: 30s
+    timeout: 5s
+    start_period: 10s
+    retries: 3
+  logging: &common-logging
+    driver: json-file
+    options:
+      max-size: "${LOG_MAX_SIZE:-10m}"
+      max-file: "${LOG_MAX_FILE:-3}"
+  deploy: &common-deploy
+    resources:
+      limits:
+        cpus: "${CPU_LIMIT:-1.0}"
+        memory: "${MEMORY_LIMIT:-512M}"
+      reservations:
+        cpus: "${CPU_RESERVATION:-0.25}"
+        memory: "${MEMORY_RESERVATION:-128M}"
+
+# ---------------------------------------------------------------------------
+# Services
+# ---------------------------------------------------------------------------
 services:
+  # Production: uses the published multi-arch image from ghcr.io.
+  # Runs by default with `docker compose up`.
   dolphin-mcp-pilot:
-    build: .
+    <<: *common
     container_name: dolphin-mcp-pilot
-    restart: unless-stopped
+    image: ghcr.io/iflytek/dolphin-mcp-pilot:${IMAGE_TAG:-latest}
+    # Host port is configurable via MCP_PORT; container port is fixed at 8001.
     ports:
-      - "8001:8001"
-    env_file:
-      - .env
-    environment:
-      DS_MCP_TRANSPORT: "http"
-      MCP_HOST: "0.0.0.0"
-      MCP_PORT: "8001"
+      - "${MCP_PORT:-8001}:8001"
+
+  # Development: builds from local Dockerfile, mounts source read-only.
+  # Activate with `docker compose --profile dev up -d dolphin-mcp-pilot-dev`.
+  # Source changes require a container restart (uvicorn has no --reload).
+  dolphin-mcp-pilot-dev:
+    <<: *common
+    container_name: dolphin-mcp-pilot-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${MCP_PORT:-8001}:8001"
+    volumes:
+      - ./dolphin_mcp_pilot:/app/dolphin_mcp_pilot:ro
+    profiles:
+      - dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "A production-ready MCP server for Apache DolphinScheduler with 58 tools, multi-tenant auth, schedules, DAG creation, guided troubleshooting and raw API passthrough."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [
   { name = "dolphin-mcp-pilot contributors" }
 ]
@@ -16,7 +16,6 @@ keywords = ["mcp", "model-context-protocol", "dolphinscheduler", "workflow", "sc
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Fixes #11

## Summary

Rewrite `docker-compose.yml` as a production-ready reference that leverages the published ghcr.io image (from #10), and align `.env.example` + README docs.

### Changes

**`docker-compose.yml`** — full rewrite:

| Concern | Before | After |
|---|---|---|
| Image source | `build: .` (must build from source) | `ghcr.io/iflytek/dolphin-mcp-pilot:${IMAGE_TAG:-latest}` |
| Development workflow | manual editing | `--profile dev` builds locally, mounts source `ro` (restart required) |
| Healthcheck | inherited from Dockerfile only | explicit, with `start_period` / `retries` |
| Logging | default (unbounded) | `json-file`, `max-size: 10m`, `max-file: 3` |
| Resources | none | `cpus: 1.0 / memory: 512M` limits, `0.25 / 128M` reservations |
| Port convention | host & container both used `${MCP_PORT}` | **container fixed at 8001**, `MCP_PORT` only controls host-side mapping |
| Config reuse | n/a | YAML anchors (`x-common`) shared between prod and dev |

**Port convention (reviewer feedback addressed):**

The container always listens on `8001` internally (matches the Dockerfile `HEALTHCHECK`). The `MCP_PORT` variable in `.env` controls only the host-side port mapping:

```yaml
environment:
  MCP_PORT: "8001"   # overrides env_file to prevent leakage
ports:
  - "${MCP_PORT:-8001}:8001"   # host configurable, container pinned
```

Verified end-to-end with `MCP_PORT=19001`:
```
STATUS: Up 12 seconds (healthy)
PORTS:  0.0.0.0:19001->8001/tcp
Container 127.0.0.1:8001 reachable ✅
Host      127.0.0.1:19001 reachable ✅
```

**`.env.example`** — added Compose-tunable variables:

```bash
IMAGE_TAG=latest
LOG_MAX_SIZE=10m
LOG_MAX_FILE=3
CPU_LIMIT=1.0
MEMORY_LIMIT=512M
CPU_RESERVATION=0.25
MEMORY_RESERVATION=128M
```

`MCP_PORT` description clarified as host-side only.

**`README.md` / `README.zh-CN.md`** — Option A restructured:

- **A1 (dev mode, recommended until first release tag)**: `docker compose --profile dev up -d dolphin-mcp-pilot-dev` — wording corrected to state that source changes require a container restart (uvicorn has no `--reload`), no more "hot-reload" claim
- **A2 (prod mode)**: pulls from ghcr.io, with note explaining it requires a release tag
- **3-Step Deployment** section updated to use dev mode

Also replaced stale `your-org` placeholder with `iflytek` in clone URLs.

**`pyproject.toml`** — setuptools deprecation fixes:

| Deprecated | Replacement |
|---|---|
| `license = { text = "Apache-2.0" }` | `license = "Apache-2.0"` (SPDX string) |
| `License :: OSI Approved :: Apache Software License` classifier | Removed (covered by SPDX) |
| `setuptools>=68` | `setuptools>=77` |

Verified: `python -m build` emits **zero deprecation warnings**.

**`CHANGELOG.md`** — added `Docker Compose upgrade (issue #11)` and setuptools deprecation fix entries under `[Unreleased]`.

### Acceptance criteria (from issue #11)

- [x] `docker compose up` (no `--profile`) pulls from `ghcr.io/iflytek/dolphin-mcp-pilot:latest` and starts successfully (once first release tag is pushed)
- [x] `docker compose --profile dev up` builds from the local `Dockerfile` and mounts `./dolphin_mcp_pilot` read-only
- [x] `docker compose ps` shows the service as `healthy` after the start period
- [x] Bind-mounted volumes work under UID 1001 — dev mode uses read-only source mount; prod mode is stateless by default
- [x] Log rotation configured (`json-file`, `max-size: 10m`, `max-file: 3`)
- [x] Resource limits set (`cpus: 1.0`, `memory: 512M`)
- [x] `.env.example` lists every variable referenced by compose
- [x] README contains a Docker Compose quickstart section

### Validation

- `docker compose config` ✅ (default + `--profile dev`)
- `docker compose --profile dev up -d dolphin-mcp-pilot-dev` ✅ — STATUS: `Up (healthy)` after ~12s
- Custom `MCP_PORT=19001` end-to-end ✅ — host 19001 → container 8001, healthcheck passes
- Dev service runs as `uid=1001(dolphin_mcp) gid=1001(dolphin)` ✅
- `python -m build` emits zero deprecation warnings ✅

## Checks

- [x] No Python source changes — `ruff` / `unittest` / `bandit` unaffected
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata points to `iflytek/dolphin-mcp-pilot`
- [x] No hardcoded secrets, internal IPs, or plaintext tokens
- [x] `python -m build` succeeds cleanly with setuptools>=77
- [x] Reviewer feedback from @FenjuFu addressed (MCP_PORT consistency + hot-reload wording)

## Special notes for reviewers

- This PR only touches CI/docs/compose config + pyproject metadata. **No Python source changes.**
- Prod compose mode currently fails with `unauthorized` because the ghcr.io image isn't published yet (PR #10 not merged, no release tag pushed). README recommends dev mode until the first release tag is available.
- Drive-by cleanups: `your-org` → `iflytek` in `README*.md`, setuptools deprecation fixes in `pyproject.toml`.