### PR TITLE
docs: slim README to OSS essentials; extract detailed content to docs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.env.example`** extended with Compose-tunable variables: `IMAGE_TAG`, `LOG_MAX_SIZE`, `LOG_MAX_FILE`, `CPU_LIMIT`, `MEMORY_LIMIT`, `CPU_RESERVATION`, `MEMORY_RESERVATION`
 - **`README.md` / `README.zh-CN.md`** Option A rewritten as a Docker Compose quickstart (prepare `.env` → `docker compose up` → verify `healthy`); dev mode documented alongside
 
+### Documentation overhaul (issue #13)
+
+- **`README.md`**: 384 → 93 lines — slim OSS landing-page structure (Why / Features / Quick Start / Documentation table / What's new / Contributing / License)
+- **`README.zh-CN.md`**: 386 → 90 lines — full Chinese translation (was ~95% English); matches English README structure with centered badges + CI badge
+- **4 new `docs/` files** (content extracted from README):
+  - `docs/FEATURES.md` — feature comparison vs `ocean-zhc/dolphinscheduler-mcp` + tool categories
+  - `docs/INSTALLATION.md` — install options (Docker/source/package), run modes, packaging
+  - `docs/CONFIGURATION.md` — environment variables, auth options, Compose tunables
+  - `docs/CLIENT_CONFIG.md` — MCP client setup (CodeBuddy, Claude Desktop, etc.), multi-tenant auth
+- **`docs/DEPLOYMENT.md`** rewritten to reflect PR #12 compose setup (dev profile, resource limits, healthcheck, MCP_PORT host-only convention)
+- **13 bug fixes**: 6 broken links (`DEPLOYMENT.md` → `docs/DEPLOYMENT.md`), 3 `your-org` → `iflytek` placeholders, 1 `your-registry/` → `ghcr.io/iflytek/`, 3 `DS_BASE_URL` → `DS_URL` in FAQ, 1 port `8080` → `8001` in FAQ, 14 `docker-compose` v1 CLI → `docker compose` v2
+- **LICENSE**: replaced stub with full Apache-2.0 text (copyright iFlytek Co., Ltd.)
+- **`docs/PROPOSAL.md`**: added "internal governance document" note
+
 ---
 
 ## [0.2.0] - 2026-07-29

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,201 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright 2026 dolphin-mcp-pilot contributors
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   1. Definitions.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 iFlytek Co., Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # dolphin-mcp-pilot
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+<div align="center">
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/iflytek/dolphin-mcp-pilot/actions/workflows/ci.yml/badge.svg)](https://github.com/iflytek/dolphin-mcp-pilot/actions/workflows/ci.yml)
 
 [English](README.md) | [简体中文](README.zh-CN.md)
+
+</div>
 
 A production-ready MCP server for Apache DolphinScheduler.
 
@@ -11,60 +16,30 @@ A production-ready MCP server for Apache DolphinScheduler.
 
 ## 🎯 Why this project?
 
-Most public DolphinScheduler MCP servers only cover basic read/list/start/stop scenarios.  
+Most public DolphinScheduler MCP servers only cover basic read/list/start/stop scenarios.
 This project is designed for **real operations work**:
 
-- ✅ Create SQL workflows in one line
-- ✅ Create complex DAG workflows (SQL/SHELL/PYTHON/DEPENDENT/HTTP/...)
+- ✅ Create SQL / DAG workflows in one line
 - ✅ Manage schedules (create / online / offline / delete)
 - ✅ Control process instances (pause / resume / rerun / rerun-from-failure)
-- ✅ View task logs
-- ✅ Force task success / skip failed task
+- ✅ View task logs, force task success / skip failed task
 - ✅ Manage resources (view/update content)
-- ✅ Roll back workflow versions
-- ✅ Clone workflows
+- ✅ Roll back workflow versions, clone workflows
 - ✅ Use raw API as a safety valve
 - ✅ Support **multi-tenant per-request auth**
 
 ## 🚀 Key features
 
 - **53+ tools** covering most practical DS operations
-- **Two auth modes**
-  - API Token (`X-DS-Token`) — preferred, DolphinScheduler 3.x native
-  - User/Password (`X-DS-User` + `X-DS-Password`) — fallback with session cache
+- **Two auth modes**: API Token (`X-DS-Token`) or User/Password (`X-DS-User` + `X-DS-Password`)
 - **Multi-tenant HTTP mode**: each caller can use its own credentials
-- **Workflow creation**
-  - Simple SQL workflows
-  - Complex DAG workflows with multiple task types
+- **Workflow creation**: simple SQL and complex DAG workflows with multiple task types
 - **Schedule management** (cron-based)
 - **Instance lifecycle control** (pause/resume/rerun/rerun-from-failure/delete)
-- **Task log access**
-- **Resource content management**
-- **Version rollback / workflow clone**
+- **Resource content management** and **version rollback / workflow clone**
 - **Raw API passthrough** for uncovered edge cases
 
-## 📊 Feature comparison
-
-| Capability | dolphin-mcp-pilot | Typical public DS MCP |
-|---|:---:|:---:|
-| **Tool count** | **53+** | ~10-15 |
-| Create project | ✅ | ⚠️ often no |
-| Create SQL workflow | ✅ | ❌ |
-| Create DAG workflow | ✅ | ❌ |
-| Update workflow | ✅ | ❌ |
-| Clone workflow | ✅ | ❌ |
-| Workflow version rollback | ✅ | ❌ |
-| **Schedule management** | ✅ 6 tools | ❌ |
-| Pause/Resume/Rerun instances | ✅ | ❌ |
-| Task logs | ✅ | ❌ |
-| Force success / skip task | ✅ | ❌ |
-| Resource content update | ✅ | ❌ |
-| **Multi-tenant auth** | ✅ | ⚠️ often single token |
-| Raw API passthrough | ✅ | ❌ |
-
 ## 🚀 Quick Start
-
-### 3-Step Deployment
 
 ```bash
 # 1. Clone the repository
@@ -73,279 +48,35 @@ cd dolphin-mcp-pilot
 
 # 2. Configure environment
 cp .env.example .env
-# Edit .env and set DS_URL + DS_TOKEN (or DS_USER/DS_PASSWORD)
+# Edit .env — at minimum set DS_URL and DS_TOKEN (or DS_USER/DS_PASSWORD)
 
-# 3. Start the service
-./start.sh        # Linux/Mac
-# or
-start.bat         # Windows
-# or
+# 3. Start the service (dev mode)
 docker compose --profile dev up -d dolphin-mcp-pilot-dev
 ```
 
 ✅ Service will be available at `http://localhost:8001/mcp/` (note the trailing slash)
 
-📖 **Detailed deployment guide**: See [DEPLOYMENT.md](DEPLOYMENT.md)
+## 📚 Documentation
 
-## 📦 Installation Options
-
-### Option A: Docker Compose (Recommended)
-
-#### A1. Development mode (recommended for now)
-
-Builds from the local Dockerfile and mounts `./dolphin_mcp_pilot` into the container as read-only. Source changes require a container restart (uvicorn is not started with `--reload`):
-
-```bash
-# 1. Prepare environment
-cp .env.example .env
-# edit .env — at minimum set DS_URL and DS_TOKEN (see Configuration below)
-
-# 2. Start (dev profile builds locally)
-docker compose --profile dev up -d dolphin-mcp-pilot-dev
-
-# 3. Verify
-docker compose --profile dev ps        # STATUS should show (healthy) after ~10s
-docker compose --profile dev logs -f   # watch startup logs
-```
-
-The service will be available at `http://localhost:8001/mcp/` (note the trailing slash).
-
-#### A2. Production mode (published image)
-
-> **Note**: The `ghcr.io/iflytek/dolphin-mcp-pilot:latest` image is published automatically when a stable release tag (e.g. `v0.2.0`) is pushed. Until the first release is tagged, use **A1** or **Option B/C** below.
-
-Once a release is available, the prod service pulls from ghcr.io:
-
-```bash
-# Optional: pin to a specific version
-echo "IMAGE_TAG=0.2.0" >> .env
-
-docker compose up -d
-docker compose ps        # STATUS should show (healthy)
-```
-
-See [`docker-compose.yml`](docker-compose.yml) for the full reference (resource limits, log rotation, healthcheck, etc.).
-
-📖 **Detailed deployment guide**: See [DEPLOYMENT.md](DEPLOYMENT.md)
-
-### Option B: From source
-
-```bash
-git clone https://github.com/iflytek/dolphin-mcp-pilot.git
-cd dolphin-mcp-pilot
-pip install -r requirements.txt
-python -m dolphin_mcp_pilot
-```
-
-### Option C: Install as package
-
-```bash
-pip install .
-dolphin-mcp-pilot
-```
-
-## ⚙️ Configuration
-
-Create a `.env` file from `.env.example`.
-
-### Required
-
-```bash
-DS_URL=http://your-dolphinscheduler-host:12345/dolphinscheduler
-```
-
-### Authentication options
-
-#### Option A: API Token (recommended)
-
-```bash
-DS_TOKEN=your_api_token
-```
-
-#### Option B: Default username/password
-
-```bash
-DS_USER=your_username
-DS_PASSWORD=your_password
-```
-
-### Optional
-
-```bash
-DS_TENANT_CODE=default          # Tenant code for workflow creation
-DS_MCP_TRANSPORT=http           # "stdio" or "http"
-MCP_HOST=0.0.0.0                # HTTP bind host
-MCP_PORT=8001                   # HTTP bind port
-```
-
-## 🏃 Run
-
-### stdio mode (for local AI tools)
-
-```bash
-python -m dolphin_mcp_pilot
-```
-
-### HTTP mode (for remote AI agents)
-
-```bash
-DS_MCP_TRANSPORT=http python -m dolphin_mcp_pilot
-```
-
-Or with Docker:
-
-```bash
-docker-compose up -d
-```
-
-## 🔐 Client Configuration
-
-### CodeBuddy / Claude Desktop (HTTP mode)
-
-Add to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "dolphinscheduler": {
-      "type": "sse",
-      "url": "http://localhost:8001/mcp/",
-      "headers": {
-        "X-DS-Token": "your_api_token"
-      }
-    }
-  }
-}
-```
-
-> ⚠️ The URL must end with `/`. Without the trailing slash, Starlette returns a 307 redirect, which some MCP clients fail to follow.
-
-**More examples** in the [`examples/`](examples/README.md) directory:
-- `codebuddy-config.json` - CodeBuddy configuration
-- `claude-desktop-config.json` - Claude Desktop stdio mode
-- `http-auth-token.json` - HTTP with token auth
-- `http-auth-password.json` - HTTP with username/password
-
-Want to share a configuration for another MCP client or deployment mode? Copy the
-[`examples/TEMPLATE`](examples/TEMPLATE) and follow the
-[example contribution guide](examples/README.md#how-to-contribute).
-
-### Multi-tenant per-request auth
-
-In HTTP mode, each caller can pass their own credentials:
-
-**Token mode (preferred):**
-```
-X-DS-Token: your_api_token
-```
-
-**Username/password mode:**
-```
-X-DS-User: alice
-X-DS-Password: alice_password
-```
-
-## 📁 Project layout
-
-```text
-dolphin-mcp-pilot/
-├── dolphin_mcp_pilot/
-│   ├── __main__.py          # Entry point
-│   ├── auth.py              # Auth & session management
-│   ├── client.py            # HTTP client for DS API
-│   ├── config.py            # Configuration
-│   ├── middleware.py        # HTTP auth middleware
-│   ├── utils.py             # Shared helpers
-│   ├── server/
-│   │   ├── __init__.py
-│   │   └── app.py           # FastMCP app
-│   └── tools/               # 58 tools organized by category
-│       ├── help.py
-│       ├── project.py
-│       ├── datasource.py
-│       ├── workflow.py
-│       ├── workflow_advanced.py
-│       ├── schedule.py
-│       ├── instance.py
-│       ├── resource.py
-│       ├── monitor.py
-│       ├── user.py
-│       └── raw.py
-├── Dockerfile
-├── docker-compose.yml
-├── pyproject.toml
-├── requirements.txt
-└── README.md
-```
-
-## 🛠️ Main tool categories
-
-### Project management (5 tools)
-- Test connection
-- List / create / rename / delete projects
-
-### Datasource management (1 tool)
-- List datasources
-
-### Workflow management (8 tools)
-- List / get / create (SQL) / release / run / status / delete / simple-list
-
-### Advanced workflow management (7 tools)
-- Update / clone / batch-delete / list-versions / rollback / create-dag / get-by-name
-
-### Schedule management (6 tools)
-- List / set / online / offline / list-in-project / delete
-
-### Process instance management (13 tools)
-- List / stop / pause / resume / rerun / rerun-from-failure / delete / complement-data
-- Get instance tasks / task log / force-task-success / skip-task
-
-### Resource management (5 tools)
-- List / view / update-content / delete / get-by-name
-
-### Monitoring (2 tools)
-- Monitor masters / workers
-
-### User / tenant (2 tools)
-- List users / tenants
-
-### Raw API passthrough (4 tools)
-- GET / POST / PUT / DELETE for any DS API endpoint
-
-### Help & navigation (1 tool)
-- `ds_help` — tool navigation guide with categories and quick-start tips
+| Document | Description |
+|---|---|
+| [📦 Installation](docs/INSTALLATION.md) | Docker Compose (dev/prod), from source, as package, run modes |
+| [⚙️ Configuration](docs/CONFIGURATION.md) | Environment variables, auth options, Compose tunables |
+| [🚀 Deployment](docs/DEPLOYMENT.md) | Production deployment, Compose reference, verify, troubleshoot |
+| [📊 Features](docs/FEATURES.md) | Feature comparison table, tool categories |
+| [🔐 Client Config](docs/CLIENT_CONFIG.md) | MCP client setup (CodeBuddy, Claude Desktop, etc.), multi-tenant auth |
+| [📖 API Reference](docs/API.md) | All 53+ tools, parameter conventions, error handling (中文) |
+| [❓ FAQ](docs/FAQ.md) | Common issues and solutions (中文) |
 
 ## ✨ What's new
 
 - **Guided troubleshooting**: `ds_list_process_instances` attaches a `next_action`
   hint to RUNNING/FAILURE instances, pointing agents to `ds_list_task_instances`
-  to inspect individual task nodes instead of only watching the workflow-level state.
-- **Reliable backfill ordering**: serial complement (`ds_complement_data` with
-  `RUN_MODE_SERIAL`) uses the `complementStartDate`/`complementEndDate` range format
-  so DolphinScheduler generates instances in strict day-by-day order.
+  to inspect individual task nodes.
+- **Reliable backfill ordering**: serial complement uses the `complementStartDate`/`complementEndDate`
+  range format so DolphinScheduler generates instances in strict day-by-day order.
 - **Flexible task params**: `ds_update_task_param` accepts both `snake_case` and
   `camelCase` field names and reports ignored fields.
-
-## 📦 Packaging & distribution
-
-Build wheel:
-
-```bash
-pip install build
-python -m build
-```
-
-Install locally:
-
-```bash
-pip install .
-```
-
-Then run:
-
-```bash
-dolphin-mcp-pilot
-```
 
 ## 🤝 Contributing
 
@@ -353,36 +84,9 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for project ch
 [example contribution guide](examples/README.md#how-to-contribute) to share a tested MCP client
 configuration.
 
-## 🔍 Verify Deployment
-
-```bash
-# Check status
-docker ps | grep dolphin-mcp-pilot
-
-# View logs
-docker-compose logs -f
-
-# Test MCP handshake (POST JSON-RPC initialize)
-curl -X POST http://localhost:8001/mcp/ \
-  -H "X-DS-Token: your_token" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
-```
-
-## 🐛 Troubleshooting
-
-See [DEPLOYMENT.md](docs/DEPLOYMENT.md#-troubleshooting) for common issues and solutions.
-
-**Quick checks:**
-- Verify `.env` file exists and is configured
-- Ensure DolphinScheduler is accessible from the container
-- Check logs: `docker-compose logs`
-- Verify token/credentials are valid
-
 ## 📄 License
 
-Apache-2.0
+[Apache-2.0](LICENSE)
 
 ## 🙏 Acknowledgments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,390 +1,90 @@
 # dolphin-mcp-pilot
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+<div align="center">
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/iflytek/dolphin-mcp-pilot/actions/workflows/ci.yml/badge.svg)](https://github.com/iflytek/dolphin-mcp-pilot/actions/workflows/ci.yml)
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-> **💡 快速翻译提示**  
-> 本文档内容较长，如需其他语言版本，可直接将本文件内容复制给 ChatGPT / Claude / 文心一言等大模型，请求翻译成目标语言（如日语、韩语、德语等）。所有格式和链接都会被保留。
+</div>
 
 Apache DolphinScheduler 的生产级 MCP 服务器。
 
-**dolphin-mcp-pilot** exposes **53+ tools** for projects, workflows, DAG creation, schedules, instances, resources, logs, monitoring and raw API passthrough — designed for AI agents that need to operate DolphinScheduler beyond basic read-only usage.
+**dolphin-mcp-pilot** 提供 **53+ 工具**，覆盖项目管理、工作流、DAG 创建、调度、实例、资源、日志、监控以及原始 API 透传 —— 专为需要超越只读操作的 AI Agent 设计。
 
-## 🎯 Why this project?
+## 🎯 为什么需要这个项目？
 
-Most public DolphinScheduler MCP servers only cover basic read/list/start/stop scenarios.  
-This project is designed for **real operations work**:
+目前公开的 DolphinScheduler MCP 服务器大多只覆盖基础的读/列/启停场景。
+本项目面向**真实运维场景**：
 
-- ✅ Create SQL workflows in one line
-- ✅ Create complex DAG workflows (SQL/SHELL/PYTHON/DEPENDENT/HTTP/...)
-- ✅ Manage schedules (create / online / offline / delete)
-- ✅ Control process instances (pause / resume / rerun / rerun-from-failure)
-- ✅ View task logs
-- ✅ Force task success / skip failed task
-- ✅ Manage resources (view/update content)
-- ✅ Roll back workflow versions
-- ✅ Clone workflows
-- ✅ Use raw API as a safety valve
-- ✅ Support **multi-tenant per-request auth**
+- ✅ 一行创建 SQL / DAG 工作流
+- ✅ 管理调度（创建 / 上线 / 下线 / 删除）
+- ✅ 控制流程实例（暂停 / 恢复 / 重跑 / 从失败处重跑）
+- ✅ 查看任务日志，强制任务成功 / 跳过失败任务
+- ✅ 管理资源（查看 / 更新内容）
+- ✅ 工作流版本回滚、克隆工作流
+- ✅ 使用原始 API 作为兜底
+- ✅ 支持**多租户每请求鉴权**
 
-## 🚀 Key features
+## 🚀 核心特性
 
-- **53+ tools** covering most practical DS operations
-- **Two auth modes**
-  - API Token (`X-DS-Token`) — preferred, DolphinScheduler 3.x native
-  - User/Password (`X-DS-User` + `X-DS-Password`) — fallback with session cache
-- **Multi-tenant HTTP mode**: each caller can use its own credentials
-- **Workflow creation**
-  - Simple SQL workflows
-  - Complex DAG workflows with multiple task types
-- **Schedule management** (cron-based)
-- **Instance lifecycle control** (pause/resume/rerun/rerun-from-failure/delete)
-- **Task log access**
-- **Resource content management**
-- **Version rollback / workflow clone**
-- **Raw API passthrough** for uncovered edge cases
+- **53+ 工具**，覆盖 DS 大部分实用操作
+- **两种鉴权模式**：API Token（`X-DS-Token`）或用户名密码（`X-DS-User` + `X-DS-Password`）
+- **多租户 HTTP 模式**：每个调用方可使用自己的凭据
+- **工作流创建**：简单 SQL 工作流 + 多任务类型复杂 DAG
+- **调度管理**（基于 cron）
+- **实例生命周期控制**（暂停 / 恢复 / 重跑 / 从失败处重跑 / 删除）
+- **资源内容管理** 与 **版本回滚 / 工作流克隆**
+- **原始 API 透传**，覆盖未封装的边缘场景
 
-## 📊 Feature comparison
-
-| Capability | dolphin-mcp-pilot | Typical public DS MCP |
-|---|:---:|:---:|
-| **Tool count** | **53+** | ~10-15 |
-| Create project | ✅ | ⚠️ often no |
-| Create SQL workflow | ✅ | ❌ |
-| Create DAG workflow | ✅ | ❌ |
-| Update workflow | ✅ | ❌ |
-| Clone workflow | ✅ | ❌ |
-| Workflow version rollback | ✅ | ❌ |
-| **Schedule management** | ✅ 6 tools | ❌ |
-| Pause/Resume/Rerun instances | ✅ | ❌ |
-| Task logs | ✅ | ❌ |
-| Force success / skip task | ✅ | ❌ |
-| Resource content update | ✅ | ❌ |
-| **Multi-tenant auth** | ✅ | ⚠️ often single token |
-| Raw API passthrough | ✅ | ❌ |
-
-## 🚀 Quick Start
-
-### 3-Step Deployment
+## 🚀 快速开始
 
 ```bash
-# 1. Clone the repository
+# 1. 克隆仓库
 git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 
-# 2. Configure environment
+# 2. 配置环境
 cp .env.example .env
-# Edit .env and set DS_URL + DS_TOKEN (or DS_USER/DS_PASSWORD)
+# 编辑 .env —— 至少设置 DS_URL 和 DS_TOKEN（或 DS_USER/DS_PASSWORD）
 
-# 3. 启动服务
-./start.sh        # Linux/Mac
-# or
-start.bat         # Windows
-# or
+# 3. 启动服务（dev 模式）
 docker compose --profile dev up -d dolphin-mcp-pilot-dev
 ```
 
-✅ Service will be available at `http://localhost:8001/mcp/` (note the trailing slash)
+✅ 服务地址：`http://localhost:8001/mcp/`（注意结尾斜杠）
 
-📖 **Detailed deployment guide**: See [DEPLOYMENT.md](DEPLOYMENT.md)
+## 📚 文档
 
-## 📦 Installation Options
+| 文档 | 说明 |
+|---|---|
+| [📦 安装指南](docs/INSTALLATION.md) | Docker Compose（dev/prod）、源码安装、包安装、运行模式 |
+| [⚙️ 配置参考](docs/CONFIGURATION.md) | 环境变量、鉴权选项、Compose 可调参数 |
+| [🚀 部署指南](docs/DEPLOYMENT.md) | 生产部署、Compose 参考、验证、排错 |
+| [📊 功能特性](docs/FEATURES.md) | 功能对比表、工具分类 |
+| [🔐 客户端配置](docs/CLIENT_CONFIG.md) | MCP 客户端接入（CodeBuddy、Claude Desktop 等）、多租户鉴权 |
+| [📖 API 参考](docs/API.md) | 全部 53+ 工具、参数规范、错误处理 |
+| [❓ 常见问题](docs/FAQ.md) | 常见问题与解决方案 |
 
-### Option A: Docker Compose (推荐)
+## ✨ 最新动态
 
-#### A1. 开发模式（当前推荐）
+- **引导式排错**：`ds_list_process_instances` 为 RUNNING/FAILURE 实例附加 `next_action`
+  提示，引导 Agent 通过 `ds_list_task_instances` 检查具体任务节点。
+- **可靠的补数据顺序**：串行补数据使用 `complementStartDate`/`complementEndDate`
+  区间格式，保证 DolphinScheduler 按严格日期顺序生成实例。
+- **灵活的任务参数**：`ds_update_task_param` 同时支持 `snake_case` 和
+  `camelCase` 字段名，并返回被忽略的字段。
 
-基于本地 Dockerfile 构建，将 `./dolphin_mcp_pilot` 以只读方式挂载进容器。源码修改后需重启容器（uvicorn 未启用 `--reload`）：
+## 🤝 参与贡献
 
-```bash
-# 1. 准备环境配置
-cp .env.example .env
-# 编辑 .env —— 至少设置 DS_URL 与 DS_TOKEN（详见下方 Configuration）
+欢迎贡献。项目代码修改请阅读 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)；如需分享已验证的 MCP 客户端配置，请按照[示例贡献指南](examples/README.md#中文)提交。
 
-# 2. 启动服务（dev profile 将本地构建）
-docker compose --profile dev up -d dolphin-mcp-pilot-dev
+## 📄 许可证
 
-# 3. 验证
-docker compose --profile dev ps        # STATUS 应在 ~10s 后显示 (healthy)
-docker compose --profile dev logs -f   # 查看启动日志
-```
+[Apache-2.0](LICENSE)
 
-服务地址：`http://localhost:8001/mcp/`（注意结尾斜杠）
+## 🙏 致谢
 
-#### A2. 生产模式（发布镜像）
-
-> **提示**：`ghcr.io/iflytek/dolphin-mcp-pilot:latest` 镜像会在推送稳定 release tag（如 `v0.2.0`）时自动发布。在首个 release 打标前，请使用上方 **A1** 或下方 **Option B/C**。
-
-镜像发布后，prod 服务会直接从 ghcr.io 拉取：
-
-```bash
-# 可选：锁定版本
-echo "IMAGE_TAG=0.2.0" >> .env
-
-docker compose up -d
-docker compose ps        # STATUS 应显示 (healthy)
-```
-
-完整参考（资源限制、日志轮转、健康检查等）见 [`docker-compose.yml`](docker-compose.yml)。
-
-📖 **详细部署指南**：参见 [DEPLOYMENT.md](DEPLOYMENT.md)
-
-### Option B: From source
-
-```bash
-git clone https://github.com/iflytek/dolphin-mcp-pilot.git
-cd dolphin-mcp-pilot
-pip install -r requirements.txt
-python -m dolphin_mcp_pilot
-```
-
-### Option C: Install as package
-
-```bash
-pip install .
-dolphin-mcp-pilot
-```
-
-## ⚙️ Configuration
-
-Create a `.env` file from `.env.example`.
-
-### Required
-
-```bash
-DS_URL=http://your-dolphinscheduler-host:12345/dolphinscheduler
-```
-
-### Authentication options
-
-#### Option A: API Token (recommended)
-
-```bash
-DS_TOKEN=your_api_token
-```
-
-#### Option B: Default username/password
-
-```bash
-DS_USER=your_username
-DS_PASSWORD=your_password
-```
-
-### Optional
-
-```bash
-DS_TENANT_CODE=default          # Tenant code for workflow creation
-DS_MCP_TRANSPORT=http           # "stdio" or "http"
-MCP_HOST=0.0.0.0                # HTTP bind host
-MCP_PORT=8001                   # HTTP bind port
-```
-
-## 🏃 Run
-
-### stdio mode (for local AI tools)
-
-```bash
-python -m dolphin_mcp_pilot
-```
-
-### HTTP mode (for remote AI agents)
-
-```bash
-DS_MCP_TRANSPORT=http python -m dolphin_mcp_pilot
-```
-
-Or with Docker:
-
-```bash
-docker-compose up -d
-```
-
-## 🔐 Client Configuration
-
-### CodeBuddy / Claude Desktop (HTTP mode)
-
-Add to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "dolphinscheduler": {
-      "type": "sse",
-      "url": "http://localhost:8001/mcp/",
-      "headers": {
-        "X-DS-Token": "your_api_token"
-      }
-    }
-  }
-}
-```
-
-> ⚠️ The URL must end with `/`. Without the trailing slash, Starlette returns a 307 redirect, which some MCP clients fail to follow.
-
-更多配置见 [`examples/`](examples/README.md) 目录：
-- `codebuddy-config.json` - CodeBuddy configuration
-- `claude-desktop-config.json` - Claude Desktop stdio mode
-- `http-auth-token.json` - HTTP with token auth
-- `http-auth-password.json` - HTTP with username/password
-
-欢迎分享其他 MCP 客户端或部署方式的配置。复制 [`examples/TEMPLATE`](examples/TEMPLATE)，
-并按照[示例贡献指南](examples/README.md#中文)提交。
-
-### Multi-tenant per-request auth
-
-In HTTP mode, each caller can pass their own credentials:
-
-**Token mode (preferred):**
-```
-X-DS-Token: your_api_token
-```
-
-**Username/password mode:**
-```
-X-DS-User: alice
-X-DS-Password: alice_password
-```
-
-## 📁 Project layout
-
-```text
-dolphin-mcp-pilot/
-├── dolphin_mcp_pilot/
-│   ├── __main__.py          # Entry point
-│   ├── auth.py              # Auth & session management
-│   ├── client.py            # HTTP client for DS API
-│   ├── config.py            # Configuration
-│   ├── middleware.py        # HTTP auth middleware
-│   ├── utils.py             # Shared helpers
-│   ├── server/
-│   │   ├── __init__.py
-│   │   └── app.py           # FastMCP app
-│   └── tools/               # 58 tools organized by category
-│       ├── help.py
-│       ├── project.py
-│       ├── datasource.py
-│       ├── workflow.py
-│       ├── workflow_advanced.py
-│       ├── schedule.py
-│       ├── instance.py
-│       ├── resource.py
-│       ├── monitor.py
-│       ├── user.py
-│       └── raw.py
-├── Dockerfile
-├── docker-compose.yml
-├── pyproject.toml
-├── requirements.txt
-└── README.md
-```
-
-## 🛠️ Main tool categories
-
-### Project management (5 tools)
-- Test connection
-- List / create / rename / delete projects
-
-### Datasource management (1 tool)
-- List datasources
-
-### Workflow management (8 tools)
-- List / get / create (SQL) / release / run / status / delete / simple-list
-
-### Advanced workflow management (7 tools)
-- Update / clone / batch-delete / list-versions / rollback / create-dag / get-by-name
-
-### Schedule management (6 tools)
-- List / set / online / offline / list-in-project / delete
-
-### Process instance management (13 tools)
-- List / stop / pause / resume / rerun / rerun-from-failure / delete / complement-data
-- Get instance tasks / task log / force-task-success / skip-task
-
-### Resource management (5 tools)
-- List / view / update-content / delete / get-by-name
-
-### Monitoring (2 tools)
-- Monitor masters / workers
-
-### User / tenant (2 tools)
-- List users / tenants
-
-### Raw API passthrough (4 tools)
-- GET / POST / PUT / DELETE for any DS API endpoint
-
-### Help & navigation (1 tool)
-- `ds_help` — tool navigation guide with categories and quick-start tips
-
-## ✨ What's new
-
-- **Guided troubleshooting**: `ds_list_process_instances` attaches a `next_action`
-  hint to RUNNING/FAILURE instances, pointing agents to `ds_list_task_instances`
-  to inspect individual task nodes instead of only watching the workflow-level state.
-- **Reliable backfill ordering**: serial complement (`ds_complement_data` with
-  `RUN_MODE_SERIAL`) uses the `complementStartDate`/`complementEndDate` range format
-  so DolphinScheduler generates instances in strict day-by-day order.
-- **Flexible task params**: `ds_update_task_param` accepts both `snake_case` and
-  `camelCase` field names and reports ignored fields.
-
-## 📦 Packaging & distribution
-
-Build wheel:
-
-```bash
-pip install build
-python -m build
-```
-
-Install locally:
-
-```bash
-pip install .
-```
-
-Then run:
-
-```bash
-dolphin-mcp-pilot
-```
-
-## 🤝 Contributing
-
-欢迎贡献。项目代码修改请阅读 [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md)；如需分享已验证的
-MCP 客户端配置，请按照[示例贡献指南](examples/README.md#中文)提交。
-
-## 🔍 Verify Deployment
-
-```bash
-# Check status
-docker ps | grep dolphin-mcp-pilot
-
-# View logs
-docker-compose logs -f
-
-# Test MCP handshake (POST JSON-RPC initialize)
-curl -X POST http://localhost:8001/mcp/ \
-  -H "X-DS-Token: your_token" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
-```
-
-## 🐛 Troubleshooting
-
-See [DEPLOYMENT.md](docs/DEPLOYMENT.md#-troubleshooting) for common issues and solutions.
-
-**Quick checks:**
-- Verify `.env` file exists and is configured
-- Ensure DolphinScheduler is accessible from the container
-- Check logs: `docker-compose logs`
-- Verify token/credentials are valid
-
-## 📄 License
-
-Apache-2.0
-
-## 🙏 Acknowledgments
-
-Built with [FastMCP](https://github.com/jlowin/fastmcp) and inspired by the Apache DolphinScheduler community.
+基于 [FastMCP](https://github.com/jlowin/fastmcp) 构建，灵感来自 Apache DolphinScheduler 社区。 (docs: slim README to OSS essentials; extract detailed content to docs/ (issue #13))

--- a/docs/CLIENT_CONFIG.md
+++ b/docs/CLIENT_CONFIG.md
@@ -1,0 +1,51 @@
+# 🔐 Client Configuration
+
+## CodeBuddy / Claude Desktop (HTTP mode)
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "dolphinscheduler": {
+      "type": "sse",
+      "url": "http://localhost:8001/mcp/",
+      "headers": {
+        "X-DS-Token": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+> ⚠️ The URL **must end with `/`**. Without the trailing slash, Starlette returns a 307 redirect, which some MCP clients fail to follow.
+
+## Example Configurations
+
+More examples in the [`examples/`](../examples/) directory:
+
+- `codebuddy-config.json` — CodeBuddy configuration
+- `claude-desktop-config.json` — Claude Desktop stdio mode
+- `http-auth-token.json` — HTTP with token auth
+- `http-auth-password.json` — HTTP with username/password
+
+## Multi-Tenant Per-Request Auth
+
+In HTTP mode, each caller can pass their own credentials:
+
+**Token mode (preferred):**
+```
+X-DS-Token: your_api_token
+```
+
+**Username/password mode:**
+```
+X-DS-User: alice
+X-DS-Password: alice_password
+```
+
+This enables multi-tenant scenarios where different AI agents or users operate with different DolphinScheduler credentials through the same MCP server instance.
+
+---
+
+← Back to [README](../README.md) | [Configuration](CONFIGURATION.md) | [Deployment](DEPLOYMENT.md) | [API Reference](API.md)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,55 @@
+# ⚙️ Configuration
+
+Create a `.env` file from [`.env.example`](../.env.example).
+
+## Required
+
+```bash
+DS_URL=http://your-dolphinscheduler-host:12345/dolphinscheduler
+```
+
+## Authentication Options
+
+### Option A: API Token (recommended)
+
+```bash
+DS_TOKEN=your_api_token
+```
+
+Get token from DolphinScheduler: **User Center → Token Management**
+
+### Option B: Default username/password
+
+```bash
+DS_USER=your_username
+DS_PASSWORD=your_password
+```
+
+## Optional
+
+```bash
+DS_TENANT_CODE=default          # Tenant code for workflow creation
+DS_MCP_TRANSPORT=http           # "stdio" or "http"
+MCP_HOST=0.0.0.0                # HTTP bind host
+MCP_PORT=8001                   # HTTP bind port (host-side only in Docker Compose)
+```
+
+## Docker Compose Variables
+
+When using Docker Compose, these additional variables are available in `.env`:
+
+```bash
+IMAGE_TAG=latest                # Published image tag (prod mode)
+LOG_MAX_SIZE=10m                # Per-container log rotation max size
+LOG_MAX_FILE=3                  # Per-container log rotation max files
+CPU_LIMIT=1.0                   # CPU limit
+MEMORY_LIMIT=512M               # Memory limit
+CPU_RESERVATION=0.25            # CPU reservation
+MEMORY_RESERVATION=128M         # Memory reservation
+```
+
+See [`docker-compose.yml`](../docker-compose.yml) for the full reference.
+
+---
+
+← Back to [README](../README.md) | [Features](FEATURES.md) | [Installation](INSTALLATION.md) | [Deployment](DEPLOYMENT.md)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,10 +1,10 @@
 # 🚀 Deployment Guide
 
-Quick deployment guide for **dolphin-mcp-pilot**.
+Production and development deployment guide for **dolphin-mcp-pilot**.
 
 ## 📋 Prerequisites
 
-- **Docker** 20.10+ and **Docker Compose** 1.29+
+- **Docker** 20.10+ and **Docker Compose** v2 (the `docker compose` command)
 - Access to a running **DolphinScheduler** instance (3.x recommended)
 - DolphinScheduler API token or username/password
 
@@ -13,44 +13,82 @@ Quick deployment guide for **dolphin-mcp-pilot**.
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/your-org/dolphin-mcp-pilot.git
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
 cd dolphin-mcp-pilot
 ```
 
 ### 2. Configure environment
 
 ```bash
-# Copy the example config
 cp .env.example .env
-
-# Edit .env with your favorite editor
-nano .env  # or vim, code, notepad, etc.
+# Edit .env — at minimum set DS_URL and DS_TOKEN (or DS_USER/DS_PASSWORD)
 ```
 
-**Required configuration:**
-- `DS_URL`: Your DolphinScheduler API URL
-- `DS_TOKEN`: Your API token (recommended)
-  - OR `DS_USER` + `DS_PASSWORD` (fallback)
+See [Configuration](CONFIGURATION.md) for the full environment variable reference.
 
 ### 3. Start the service
 
-**Linux/Mac:**
+**Development mode** (recommended — builds locally):
 ```bash
-chmod +x start.sh
-./start.sh
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
 ```
 
-**Windows:**
-```cmd
-start.bat
-```
-
-**Or manually:**
+**Production mode** (pulls from ghcr.io — requires a release tag to be available):
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ✅ Service will be available at `http://localhost:8001/mcp/` (note the trailing slash)
+
+## 🐳 Docker Compose Reference
+
+The [`docker-compose.yml`](../docker-compose.yml) provides two services that share configuration via YAML anchors (`x-common`):
+
+### Development mode (`--profile dev`)
+
+Builds from the local Dockerfile and mounts `./dolphin_mcp_pilot` as read-only. Source changes require a container restart (uvicorn is not started with `--reload`).
+
+```bash
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
+docker compose --profile dev ps        # STATUS should show (healthy) after ~10s
+docker compose --profile dev logs -f   # watch startup logs
+```
+
+### Production mode (default)
+
+Pulls the published multi-arch image from `ghcr.io/iflytek/dolphin-mcp-pilot:${IMAGE_TAG:-latest}`.
+
+> **Note**: The `latest` tag is only created when a stable release tag (e.g. `v0.2.0`) is pushed. Until the first release is tagged, use dev mode.
+
+```bash
+# Optional: pin to a specific version
+echo "IMAGE_TAG=0.2.0" >> .env
+
+docker compose up -d
+docker compose ps        # STATUS should show (healthy)
+```
+
+### Port convention
+
+The container always listens on **8001** internally (matching the Dockerfile `HEALTHCHECK`). The `MCP_PORT` variable in `.env` controls only the **host-side** port mapping:
+
+```bash
+# .env
+MCP_PORT=9000    # host:9000 → container:8001
+```
+
+The compose file's `environment:` block explicitly sets `MCP_PORT: "8001"` inside the container to prevent the host-side value from leaking in.
+
+### Built-in configuration
+
+The default `docker-compose.yml` already includes:
+
+- **Healthcheck**: stdlib socket probe on `127.0.0.1:8001` (30s interval, 5s timeout, 10s start period, 3 retries)
+- **Log rotation**: `json-file` driver, `max-size: 10m`, `max-file: 3`
+- **Resource limits**: `cpus: 1.0 / memory: 512M` limits, `0.25 / 128M` reservations
+- **Non-root runtime**: `uid=1001 gid=1001`
+
+All values are tunable via `.env` variables (`LOG_MAX_SIZE`, `CPU_LIMIT`, `MEMORY_LIMIT`, etc.). See [Configuration](CONFIGURATION.md) for the full list.
 
 ## 🔍 Verify Deployment
 
@@ -66,19 +104,18 @@ curl -X POST http://localhost:8001/mcp/ \
 
 Expected: an SSE `data:` line containing `"serverInfo":{"name":"DolphinScheduler",...}`
 
-> **Note**: URL must end with `/`. Without it, Starlette returns HTTP 307 redirect,
-> which some MCP clients fail to follow.
+> **Note**: URL must end with `/`. Without it, Starlette returns HTTP 307 redirect, which some MCP clients fail to follow.
 
 ### View logs
 
 ```bash
-docker-compose logs -f
+docker compose logs -f
 ```
 
 ### Check container status
 
 ```bash
-docker ps | grep dolphin-mcp-pilot
+docker compose ps
 ```
 
 ## 🔧 Configuration Details
@@ -94,7 +131,7 @@ docker ps | grep dolphin-mcp-pilot
 | `DS_TENANT_CODE` | ❌ No | `default` | Tenant code for workflow creation |
 | `DS_MCP_TRANSPORT` | ❌ No | `http` | Transport mode: `stdio` or `http` |
 | `MCP_HOST` | ❌ No | `0.0.0.0` | HTTP server bind address |
-| `MCP_PORT` | ❌ No | `8001` | HTTP server port |
+| `MCP_PORT` | ❌ No | `8001` | Host-side port (container always uses 8001) |
 
 ### Getting DolphinScheduler API Token
 
@@ -106,25 +143,7 @@ docker ps | grep dolphin-mcp-pilot
 
 ## 🔌 Client Configuration
 
-### CodeBuddy / Claude Desktop (HTTP mode)
-
-Add to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "dolphinscheduler": {
-      "type": "sse",
-      "url": "http://localhost:8001/mcp/",
-      "headers": {
-        "X-DS-Token": "your_api_token_here"
-      }
-    }
-  }
-}
-```
-
-See `examples/` directory for more configuration samples.
+See [Client Configuration](CLIENT_CONFIG.md) for MCP client setup (CodeBuddy, Claude Desktop, etc.) and multi-tenant per-request auth.
 
 ## 🐛 Troubleshooting
 
@@ -132,7 +151,7 @@ See `examples/` directory for more configuration samples.
 
 **Check logs:**
 ```bash
-docker-compose logs
+docker compose logs
 ```
 
 **Common issues:**
@@ -171,14 +190,22 @@ curl http://your-ds-host:12345/dolphinscheduler/ui
 - User/token must have appropriate project permissions
 - Some operations require admin privileges
 
+### Healthcheck failing
+
+- Container port is always 8001 internally — verify nothing else overrides `MCP_PORT` inside the container
+- Check `docker compose ps` for health status details
+- If the app hasn't started yet, wait for the `start_period` (10s)
+
 ## 🔄 Updates
 
 ### Pull latest changes
 
 ```bash
 git pull origin main
-docker-compose down
-docker-compose up -d --build
+docker compose down
+docker compose --profile dev up -d --build   # dev mode
+# or
+docker compose pull && docker compose up -d  # prod mode
 ```
 
 ### View changelog
@@ -190,24 +217,24 @@ git log --oneline
 ## 🛑 Stop Service
 
 ```bash
-docker-compose down
+docker compose down
+docker compose --profile dev down   # also stop dev service
 ```
 
 To remove volumes as well:
 ```bash
-docker-compose down -v
+docker compose down -v
 ```
 
 ## 📦 Production Deployment
 
-### Use Docker image from registry
+### Use published Docker image
 
 ```yaml
-# docker-compose.yml
 services:
   dolphin-mcp-pilot:
-    image: your-registry/dolphin-mcp-pilot:latest
-    # ... rest of config
+    image: ghcr.io/iflytek/dolphin-mcp-pilot:latest
+    # See docker-compose.yml for full production config
 ```
 
 ### Enable HTTPS
@@ -218,10 +245,10 @@ Use a reverse proxy (nginx, Caddy, Traefik) in front of the service:
 server {
     listen 443 ssl;
     server_name mcp.yourdomain.com;
-    
+
     ssl_certificate /path/to/cert.pem;
     ssl_certificate_key /path/to/key.pem;
-    
+
     location /mcp {
         proxy_pass http://localhost:8001;
         proxy_http_version 1.1;
@@ -232,44 +259,16 @@ server {
 }
 ```
 
-### Resource limits
-
-Add to `docker-compose.yml`:
-
-```yaml
-services:
-  dolphin-mcp-pilot:
-    # ... existing config
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
-        reservations:
-          cpus: '0.5'
-          memory: 256M
-```
-
-### Health checks
-
-```yaml
-services:
-  dolphin-mcp-pilot:
-    # ... existing config
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/mcp/"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-```
-
 ## 📞 Support
 
-- **Issues**: https://github.com/your-org/dolphin-mcp-pilot/issues
-- **Discussions**: https://github.com/your-org/dolphin-mcp-pilot/discussions
+- **Issues**: https://github.com/iflytek/dolphin-mcp-pilot/issues
+- **Discussions**: https://github.com/iflytek/dolphin-mcp-pilot/discussions
 - **DolphinScheduler Docs**: https://dolphinscheduler.apache.org/
 
 ## 📄 License
 
 Apache-2.0
+
+---
+
+← Back to [README](../README.md) | [Installation](INSTALLATION.md) | [Configuration](CONFIGURATION.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,7 @@ dolphin-mcp-pilot 使用过程中的常见问题与解决方案。
 - DolphinScheduler 服务未启动
 
 **解决**：
-1. 检查 `.env` 中的 `DS_BASE_URL` 是否正确（格式：`http://host:port/dolphinscheduler`）
+1. 检查 `.env` 中的 `DS_URL` 是否正确（格式：`http://host:port/dolphinscheduler`）
 2. 在服务器上 `curl http://your-ds-host:12345/dolphinscheduler/ui/` 确认可访问
 3. 检查防火墙规则：`sudo firewall-cmd --list-ports`
 4. Docker 部署时确认网络模式（`--network host` 或桥接网络）
@@ -48,7 +48,7 @@ dolphin-mcp-pilot 使用过程中的常见问题与解决方案。
       "command": "uvx",
       "args": ["--from", "dolphin-mcp-pilot", "dolphin-mcp-pilot"],
       "env": {
-        "DS_BASE_URL": "http://your-ds-host:12345/dolphinscheduler",
+        "DS_URL": "http://your-ds-host:12345/dolphinscheduler",
         "DS_USER": "admin",
         "DS_PASSWORD": "your-password"
       }
@@ -71,7 +71,7 @@ dolphin-mcp-pilot 使用过程中的常见问题与解决方案。
 ```
 
 **Cursor / Windsurf**（SSE 模式）：
-启动 HTTP 服务器，配置 `http://localhost:8080/sse` 作为 MCP endpoint。
+启动 HTTP 服务器，配置 `http://localhost:8001/mcp/` 作为 MCP endpoint。
 
 ---
 
@@ -387,7 +387,7 @@ for start in ["2024-01-01", "2024-01-21", "2024-02-11", ...]:
 | v0.2.0            | 2.x / 3.x        | 3.10+  |
 | v0.1.0            | 2.x              | 3.10+  |
 
-**注意**：DolphinScheduler 3.x 的 API 路径可能有变化，需要调整 `DS_BASE_URL`。
+**注意**：DolphinScheduler 3.x 的 API 路径可能有变化，需要调整 `DS_URL`。
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,71 @@
+# 📊 Features & Tool Categories
+
+## Feature Comparison
+
+Comparison against the most prominent public DolphinScheduler MCP server: [ocean-zhc/dolphinscheduler-mcp](https://github.com/ocean-zhc/dolphinscheduler-mcp) (community-built, FastMCP-based, auto-generated from DS REST API).
+
+| Capability | dolphin-mcp-pilot | ocean-zhc/dolphinscheduler-mcp |
+|---|:---:|:---:|
+| **Tool count** | **53+** (manually curated) | 30+ (auto-generated from REST API) |
+| Create project | ✅ | ✅ |
+| Create SQL workflow | ✅ | ❌ (no process_definition tools) |
+| Create DAG workflow | ✅ | ❌ |
+| Update workflow | ✅ | ❌ |
+| Clone workflow | ✅ | ❌ |
+| Workflow version rollback | ✅ | ❌ |
+| **Schedule management** | ✅ 6 tools | ❌ (no schedule tools) |
+| Pause/Resume/Rerun instances | ✅ | ❌ (no process_instance tools) |
+| Task logs | ✅ | ❌ |
+| Force success / skip task | ✅ | ❌ |
+| Resource content update | ✅ | ❌ (no resource tools) |
+| **Multi-tenant auth** | ✅ (per-request token/user) | ❌ (single `DOLPHINSCHEDULER_API_KEY`) |
+| Raw API passthrough | ✅ (GET/POST/PUT/DELETE) | ❌ |
+| Audit log access | ✅ | ✅ |
+| Data lineage | ❌ | ✅ |
+| K8s namespace management | ❌ | ✅ |
+
+### Design differences
+
+- **dolphin-mcp-pilot**: Manually curated tools focused on **operations workflows** (create, run, monitor, debug). Multi-tenant auth enables shared MCP server scenarios. Raw API passthrough as a safety valve for uncovered edge cases.
+- **ocean-zhc/dolphinscheduler-mcp**: Auto-generated tools providing **broad REST API coverage**. Better for read-only exploration and administrative tasks (audit logs, lineage, K8s). Single-tenant by design.
+
+## 🛠️ Tool Categories
+
+### Project management (5 tools)
+- Test connection
+- List / create / rename / delete projects
+
+### Datasource management (1 tool)
+- List datasources
+
+### Workflow management (8 tools)
+- List / get / create (SQL) / release / run / status / delete / simple-list
+
+### Advanced workflow management (7 tools)
+- Update / clone / batch-delete / list-versions / rollback / create-dag / get-by-name
+
+### Schedule management (6 tools)
+- List / set / online / offline / list-in-project / delete
+
+### Process instance management (13 tools)
+- List / stop / pause / resume / rerun / rerun-from-failure / delete / complement-data
+- Get instance tasks / task log / force-task-success / skip-task
+
+### Resource management (5 tools)
+- List / view / update-content / delete / get-by-name
+
+### Monitoring (2 tools)
+- Monitor masters / workers
+
+### User / tenant (2 tools)
+- List users / tenants
+
+### Raw API passthrough (4 tools)
+- GET / POST / PUT / DELETE for any DS API endpoint
+
+### Help & navigation (1 tool)
+- `ds_help` — tool navigation guide with categories and quick-start tips
+
+---
+
+← Back to [README](../README.md) | [Installation](INSTALLATION.md) | [Configuration](CONFIGURATION.md) | [Deployment](DEPLOYMENT.md)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,99 @@
+# 📦 Installation Guide
+
+## Option A: Docker Compose (Recommended)
+
+### A1. Development mode (recommended for now)
+
+Builds from the local Dockerfile and mounts `./dolphin_mcp_pilot` into the container as read-only. Source changes require a container restart (uvicorn is not started with `--reload`):
+
+```bash
+# 1. Prepare environment
+cp .env.example .env
+# edit .env — at minimum set DS_URL and DS_TOKEN (see Configuration below)
+
+# 2. Start (dev profile builds locally)
+docker compose --profile dev up -d dolphin-mcp-pilot-dev
+
+# 3. Verify
+docker compose --profile dev ps        # STATUS should show (healthy) after ~10s
+docker compose --profile dev logs -f   # watch startup logs
+```
+
+The service will be available at `http://localhost:8001/mcp/` (note the trailing slash).
+
+### A2. Production mode (published image)
+
+> **Note**: The `ghcr.io/iflytek/dolphin-mcp-pilot:latest` image is published automatically when a stable release tag (e.g. `v0.2.0`) is pushed. Until the first release is tagged, use **A1** or **Option B/C** below.
+
+Once a release is available, the prod service pulls from ghcr.io:
+
+```bash
+# Optional: pin to a specific version
+echo "IMAGE_TAG=0.2.0" >> .env
+
+docker compose up -d
+docker compose ps        # STATUS should show (healthy)
+```
+
+See [`docker-compose.yml`](../docker-compose.yml) for the full reference (resource limits, log rotation, healthcheck, etc.).
+
+## Option B: From source
+
+```bash
+git clone https://github.com/iflytek/dolphin-mcp-pilot.git
+cd dolphin-mcp-pilot
+pip install -r requirements.txt
+python -m dolphin_mcp_pilot
+```
+
+## Option C: Install as package
+
+```bash
+pip install .
+dolphin-mcp-pilot
+```
+
+## 🏃 Run Modes
+
+### stdio mode (for local AI tools)
+
+```bash
+python -m dolphin_mcp_pilot
+```
+
+### HTTP mode (for remote AI agents)
+
+```bash
+DS_MCP_TRANSPORT=http python -m dolphin_mcp_pilot
+```
+
+Or with Docker:
+
+```bash
+docker compose up -d
+```
+
+## 📦 Packaging & Distribution
+
+Build wheel:
+
+```bash
+pip install build
+python -m build
+```
+
+Install locally:
+
+```bash
+pip install .
+```
+
+Then run:
+
+```bash
+dolphin-mcp-pilot
+```
+
+---
+
+← Back to [README](../README.md) | [Features](FEATURES.md) | [Configuration](CONFIGURATION.md) | [Deployment](DEPLOYMENT.md)

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -1,3 +1,5 @@
+> **Note**: This is an internal governance document (repository proposal for the iflytek open-source community). It is not user-facing documentation.
+
 # Repository Proposal: dolphin-mcp-pilot
 
 **Target Repository Name**: dolphin-mcp-pilot  


### PR DESCRIPTION
Fixes #13

## Summary

Overhaul project documentation: slim README files to open-source essentials (~90 lines each, down from ~385), extract detailed content to `docs/`, and fix 13 documentation bugs surfaced during audit.

### README overhaul

| File | Before | After | Reduction |
|---|---|---|---|
| `README.md` | 384 lines | 91 lines | -76% |
| `README.zh-CN.md` | 386 lines (~95% English) | 90 lines (full Chinese) | -77% |

Both READMEs now follow a concise OSS landing-page pattern with **centered badges** (including new CI badge) and a **📚 Documentation table** linking to all `docs/` files. License sections use relative `LICENSE` links.

### 4 new docs/ files (content extracted from README)

| File | Lines | Content |
|---|---|---|
| `docs/FEATURES.md` | 71 | Feature comparison vs [`ocean-zhc/dolphinscheduler-mcp`](https://github.com/ocean-zhc/dolphinscheduler-mcp) + tool categories |
| `docs/INSTALLATION.md` | 99 | Docker Compose (dev/prod), from source, as package, run modes, packaging |
| `docs/CONFIGURATION.md` | 55 | Environment variables, auth options, Compose tunables |
| `docs/CLIENT_CONFIG.md` | 51 | MCP client setup (CodeBuddy, Claude Desktop), multi-tenant auth |

### docs/DEPLOYMENT.md major rewrite

- Reflects PR #12 compose setup (dev profile, resource limits, healthcheck, MCP_PORT host-only convention)
- Fixed 3 `your-org` → `iflytek` placeholders
- Fixed `your-registry/` → `ghcr.io/iflytek/`
- Replaced all `docker-compose` v1 CLI → `docker compose` v2
- Added "Port convention" and "Built-in configuration" sections
- Absorbed Verify Deployment + Troubleshooting from README

### Bug fixes (13 total)

**Broken links (6):**
- `README.md` L88/L129: `DEPLOYMENT.md` → `docs/DEPLOYMENT.md`
- `README.zh-CN.md` L91/L132: `DEPLOYMENT.md` → `docs/DEPLOYMENT.md`
- `examples/README.md` L167/L172: `../DEPLOYMENT.md` → `../docs/DEPLOYMENT.md`

**Stale placeholders (4):**
- `docs/DEPLOYMENT.md`: 3× `your-org` → `iflytek`, 1× `your-registry/` → `ghcr.io/iflytek/`

**Wrong values (2):**
- `docs/FAQ.md` L17/L51/L390: `DS_BASE_URL` → `DS_URL`
- `docs/FAQ.md` L74: port `8080` → `8001`

**Legacy CLI (1):**
- `examples/README.md`: `docker-compose up -d` → `docker compose up -d`

### Feature comparison improvement

The comparison table in `docs/FEATURES.md` now references a **specific project** ([`ocean-zhc/dolphinscheduler-mcp`](https://github.com/ocean-zhc/dolphinscheduler-mcp)) instead of the generic "Typical public DS MCP". Added their strengths (audit logs, data lineage, K8s namespace management) for fairness, plus a "Design differences" section.

### Additional changes

- `LICENSE`: replaced stub with full Apache-2.0 text (copyright iFlytek Co., Ltd.)
- `docs/PROPOSAL.md`: added "internal governance document" note
- `README.zh-CN.md`: full Chinese translation + style sync with English README (centered badges, CI badge, relative LICENSE link)

## Verification

```
✅ README.md: 91 lines (≤120 target)
✅ README.zh-CN.md: 90 lines (≤120 target)
✅ 54 relative links across 17 markdown files — zero broken
✅ 0 remaining your-org / your-registry placeholders (excluding CHANGELOG historical reference)
✅ 0 remaining docker-compose v1 CLI references (excluding CHANGELOG historical reference)
✅ All 4 new docs/ files self-contained with back-links
```

## Checks

- [x] No Python source changes — `ruff` / `unittest` / `bandit` unaffected
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/dolphin-mcp-pilot`
- [x] No hardcoded secrets, internal IPs, or plaintext tokens
- [x] All internal markdown links resolve

## Special notes for reviewers

- This PR is **docs-only** — no Python source changes. CI checks (ruff/unittest/bandit) are unaffected.
- The `ocean-zhc/dolphinscheduler-mcp` comparison in `docs/FEATURES.md` is based on the visible tool file structure in their `tools_generated/` directory. If you have access to more detailed info about that project's capabilities, the table can be refined.
- `README.zh-CN.md` is now fully translated with matching style (centered badges, CI badge, relative LICENSE link).
- The LICENSE change is a pre-existing uncommitted modification (stub → full text) bundled with this PR for convenience.