### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.3.0] - 2026-08-10
+
 ### Added
 
 - **Release workflow** (`.github/workflows/release.yml`): publishes multi-arch (`linux/amd64` + `linux/arm64`) images to `ghcr.io/iflytek/dolphin-mcp-pilot`

--- a/dolphin_mcp_pilot/__init__.py
+++ b/dolphin_mcp_pilot/__init__.py
@@ -27,7 +27,7 @@ Usage:
     from dolphin_mcp_pilot import mcp, ds_list_projects
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __author__ = "dolphin-mcp-pilot contributors"
 __license__ = "Apache-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dolphin-mcp-pilot"
-version = "0.2.0"
+version = "0.3.0"
 description = "A production-ready MCP server for Apache DolphinScheduler with 58 tools, multi-tenant auth, schedules, DAG creation, guided troubleshooting and raw API passthrough."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

N/A (release PR)

## Summary

This PR prepares the v0.3.0 release with Docker/Compose improvements, CI enhancements, and documentation overhaul.

### Highlights

**CI/CD**
- New release workflow (`.github/workflows/release.yml`) publishing multi-arch images (`linux/amd64` + `linux/arm64`) to `ghcr.io/iflytek/dolphin-mcp-pilot`
- `push` tag `v*.*.*` → semver tags + `latest` on stable releases
- `push` to `main` → `:<git-sha-long>` traceable pre-release builds
- Docker `HEALTHCHECK` via stdlib-socket probe (zero extra dependencies)
- OCI metadata labels for catalog indexing

**Docker**
- Multi-stage build: ~60MB image size (venv in builder → slim runtime)
- Non-root runtime (`dolphin_mcp` UID/GID `1001:1001`)
- Leaner build context via updated `.dockerignore`
- CI action bumps: `actions/checkout` v4→v7, `actions/setup-python` v5→v7

**Docker Compose (issue #11)**
- Production-ready `docker-compose.yml` with healthcheck, logging, resource limits
- Dev profile (`dolphin-mcp-pilot-dev`) for local development
- Shared config via YAML anchors (`x-common`)
- `.env.example` extended with Compose-tunable variables

**Documentation (issue #13)**
- README slimmed from 384 → 93 lines (OSS landing-page structure)
- Full Chinese translation (`README.zh-CN.md`)
- 4 new `docs/` files: `FEATURES.md`, `INSTALLATION.md`, `CONFIGURATION.md`, `CLIENT_CONFIG.md`
- 13 bug fixes (broken links, placeholder corrections, port numbers, CLI v1→v2)

**Package metadata**
- Replaced `your-org` placeholder with `iflytek`
- Migrated `project.license` to SPDX string format
- Bumped `setuptools>=77`

### Version bumps
- `pyproject.toml`: 0.2.0 → 0.3.0
- `dolphin_mcp_pilot/__init__.py`: `__version__` 0.2.0 → 0.3.0
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.0] - 2026-08-10`

## Checks

- [x] `ruff check dolphin_mcp_pilot tests`
- [x] `ruff format --check dolphin_mcp_pilot tests`
- [x] `python -m unittest discover -s tests -p 'test_*.py'`
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/dolphin-mcp-pilot`
- [x] No hardcoded secrets, internal IPs, or plaintext tokens

## Special notes for reviewers

After merging, please tag the release:
```bash
git checkout main && git pull
git tag v0.3.0
git push origin v0.3.0
```

This will trigger the release workflow to publish images to GHCR.