### PR TITLE
feat: add MCP Registry publishing

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,15 +1,22 @@
 # =============================================================================
-# Publish server.json to MCP Registry on release
+# Publish server.json to the official MCP Registry
 # =============================================================================
 # Triggers on:
 #   - New tag push (vX.Y.Z)
-#   - Manual workflow_dispatch with version input
+#   - Manual workflow_dispatch with an explicit version
 #
 # Prerequisites:
 #   - ghcr.io/iflytek/dolphin-mcp-pilot:{version} must exist (built by release.yml)
-#   - GitHub token with read:org scope (auto-provided by GITHUB_TOKEN)
+#   - that image must carry the LABEL io.modelcontextprotocol.server.name,
+#     which is how the registry verifies ownership of io.github.iflytek/*
 #
-# Registry docs: https://github.com/modelcontextprotocol/registry
+# Auth: GitHub OIDC. No PAT or long-lived secret is involved -- the default
+# GITHUB_TOKEN authenticates as github-actions[bot], which is not an iflytek
+# org member and therefore cannot prove namespace ownership.
+#
+# Registry docs:
+#   https://github.com/modelcontextprotocol/registry/blob/main/docs/
+#   modelcontextprotocol-io/github-actions.mdx
 # =============================================================================
 
 name: Publish to MCP Registry
@@ -21,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.2.0, without v prefix)'
+        description: 'Version to publish (e.g. 0.3.1, without the v prefix)'
         required: true
         type: string
 
@@ -30,8 +37,9 @@ jobs:
     name: Publish server.json to registry.modelcontextprotocol.io
     runs-on: ubuntu-latest
     permissions:
+      id-token: write   # required to mint the OIDC token
       contents: read
-      
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,37 +50,44 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else
-            VERSION="${GITHUB_REF_NAME#v}"  # strip 'v' prefix from tag
+            VERSION="${GITHUB_REF_NAME#v}"  # strip the 'v' prefix from the tag
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
-      - name: Update server.json version and OCI tag
+      - name: Sync version and OCI tag into server.json
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          # Update version field
-          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" server.json
-          # Update OCI identifier tag
-          sed -i "s|ghcr.io/iflytek/dolphin-mcp-pilot:[^\"]*|ghcr.io/iflytek/dolphin-mcp-pilot:$VERSION|" server.json
-          echo "Updated server.json:"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          jq --arg img "ghcr.io/iflytek/dolphin-mcp-pilot:$VERSION" \
+            '.packages[0].identifier = $img' server.json > server.tmp
+          mv server.tmp server.json
           cat server.json
 
-      - name: Install mcp-publisher CLI
+      # Catch schema violations here rather than at publish time, where a
+      # rejection would leave a pushed tag with nothing published against it.
+      - name: Validate server.json against the published schema
         run: |
-          # Official install via Homebrew (Ubuntu runner has brew)
-          brew install mcp-publisher
-          mcp-publisher --version
+          python -m pip install --quiet check-jsonschema
+          SCHEMA=$(jq -r '."$schema"' server.json)
+          echo "Validating against $SCHEMA"
+          python -m check_jsonschema --schemafile "$SCHEMA" server.json
 
-      - name: Authenticate with MCP Registry
+      - name: Install mcp-publisher
         run: |
-          # Use GitHub token for namespace io.github.iflytek/*
-          # --token flag uses non-interactive auth suitable for CI
-          mcp-publisher login github \
-            --token "${{ secrets.GITHUB_TOKEN }}" \
-            --registry https://registry.modelcontextprotocol.io
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --version
 
-      - name: Publish to registry
+      - name: Authenticate to the MCP Registry via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the registry
         run: |
-          mcp-publisher publish server.json
+          ./mcp-publisher publish
           echo "Published io.github.iflytek/dolphin-mcp-pilot@${{ steps.version.outputs.VERSION }}"
-          echo "View at: https://registry.modelcontextprotocol.io/servers/io.github.iflytek/dolphin-mcp-pilot"
+          echo "View at: https://registry.modelcontextprotocol.io/v0/servers?search=dolphin-mcp-pilot"

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,0 +1,78 @@
+# =============================================================================
+# Publish server.json to MCP Registry on release
+# =============================================================================
+# Triggers on:
+#   - New tag push (vX.Y.Z)
+#   - Manual workflow_dispatch with version input
+#
+# Prerequisites:
+#   - ghcr.io/iflytek/dolphin-mcp-pilot:{version} must exist (built by release.yml)
+#   - GitHub token with read:org scope (auto-provided by GITHUB_TOKEN)
+#
+# Registry docs: https://github.com/modelcontextprotocol/registry
+# =============================================================================
+
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.2.0, without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  publish-registry:
+    name: Publish server.json to registry.modelcontextprotocol.io
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"  # strip 'v' prefix from tag
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Update server.json version and OCI tag
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          # Update version field
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" server.json
+          # Update OCI identifier tag
+          sed -i "s|ghcr.io/iflytek/dolphin-mcp-pilot:[^\"]*|ghcr.io/iflytek/dolphin-mcp-pilot:$VERSION|" server.json
+          echo "Updated server.json:"
+          cat server.json
+
+      - name: Install mcp-publisher CLI
+        run: |
+          # Official install via Homebrew (Ubuntu runner has brew)
+          brew install mcp-publisher
+          mcp-publisher --version
+
+      - name: Authenticate with MCP Registry
+        run: |
+          # Use GitHub token for namespace io.github.iflytek/*
+          # --token flag uses non-interactive auth suitable for CI
+          mcp-publisher login github \
+            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --registry https://registry.modelcontextprotocol.io
+
+      - name: Publish to registry
+        run: |
+          mcp-publisher publish server.json
+          echo "Published io.github.iflytek/dolphin-mcp-pilot@${{ steps.version.outputs.VERSION }}"
+          echo "View at: https://registry.modelcontextprotocol.io/servers/io.github.iflytek/dolphin-mcp-pilot"

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,36 +1,36 @@
 # =============================================================================
-# Publish server.json to the official MCP Registry
+# Publish server.json to the official MCP Registry -- MANUAL / RECOVERY path
 # =============================================================================
-# Triggers on:
-#   - New tag push (vX.Y.Z)
-#   - Manual workflow_dispatch with an explicit version
+# Tag-driven publication lives in release.yml, as a job gated on
+# `needs: build-and-push`. That ordering matters: publication requires
+# ghcr.io/iflytek/dolphin-mcp-pilot:<version> to already exist carrying the
+# io.modelcontextprotocol.server.name label, which is how the registry proves
+# ownership of io.github.iflytek/*. Triggering both workflows from the same tag
+# let GitHub schedule them concurrently, so publish could and did race the image
+# build.
 #
-# Prerequisites:
-#   - ghcr.io/iflytek/dolphin-mcp-pilot:{version} must exist (built by release.yml)
-#   - that image must carry the LABEL io.modelcontextprotocol.server.name,
-#     which is how the registry verifies ownership of io.github.iflytek/*
+# This workflow therefore keeps only the manual path, and verifies the same
+# prerequisite explicitly before publishing.
 #
-# Auth: GitHub OIDC. No PAT or long-lived secret is involved -- the default
-# GITHUB_TOKEN authenticates as github-actions[bot], which is not an iflytek
-# org member and therefore cannot prove namespace ownership.
+# Auth: GitHub OIDC. The default GITHUB_TOKEN authenticates as
+# github-actions[bot], which is not an iflytek org member and cannot prove
+# namespace ownership.
 #
-# Registry docs:
-#   https://github.com/modelcontextprotocol/registry/blob/main/docs/
-#   modelcontextprotocol-io/github-actions.mdx
+# Docs: https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/github-actions.mdx
 # =============================================================================
 
-name: Publish to MCP Registry
+name: Publish to MCP Registry (manual)
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.3.1, without the v prefix)'
+        description: 'Version to publish, without the v prefix (e.g. 0.3.1)'
         required: true
         type: string
+
+permissions:
+  contents: read
 
 jobs:
   publish-registry:
@@ -44,20 +44,48 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Determine version
+      # The dispatch input is attacker-controlled text. Interpolating it
+      # directly into a run: block splices it into the script before bash
+      # parses it, which in a job holding id-token: write would expose the
+      # registry OIDC credential.
+      # https://docs.github.com/en/actions/concepts/security/script-injections
+      - name: Validate and export version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${GITHUB_REF_NAME#v}"  # strip the 'v' prefix from the tag
+          if ! printf '%s' "$INPUT_VERSION" \
+              | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'; then
+            echo "::error::Rejected version '$INPUT_VERSION' (expected MAJOR.MINOR.PATCH)"
+            exit 1
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Publishing version: $VERSION"
+          echo "VERSION=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $INPUT_VERSION"
+
+      # Same prerequisite the tag-driven job gets from `needs: build-and-push`.
+      - name: Verify the published image exists and carries the ownership label
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          IMAGE="ghcr.io/iflytek/dolphin-mcp-pilot:${VERSION}"
+          echo "Inspecting ${IMAGE}"
+          if ! docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "::error::${IMAGE} not found. Build and push it before publishing."
+            exit 1
+          fi
+          docker pull --quiet "${IMAGE}"
+          LABEL=$(docker inspect --format \
+            '{{index .Config.Labels "io.modelcontextprotocol.server.name"}}' "${IMAGE}")
+          echo "ownership label: ${LABEL:-<none>}"
+          if [ "${LABEL}" != "io.github.iflytek/dolphin-mcp-pilot" ]; then
+            echo "::error::Image is missing the io.modelcontextprotocol.server.name label"
+            exit 1
+          fi
 
       - name: Sync version and OCI tag into server.json
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp
           mv server.tmp server.json
           jq --arg img "ghcr.io/iflytek/dolphin-mcp-pilot:$VERSION" \
@@ -65,9 +93,10 @@ jobs:
           mv server.tmp server.json
           cat server.json
 
-      # Catch schema violations here rather than at publish time, where a
-      # rejection would leave a pushed tag with nothing published against it.
-      - name: Validate server.json against the published schema
+      # Fail here rather than at publish time: a rejected publish would leave a
+      # pushed tag with nothing published against it, and versions cannot be
+      # reused.
+      - name: Validate server.json against its declared schema
         run: |
           python -m pip install --quiet check-jsonschema
           SCHEMA=$(jq -r '."$schema"' server.json)
@@ -87,7 +116,8 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to the registry
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           ./mcp-publisher publish
-          echo "Published io.github.iflytek/dolphin-mcp-pilot@${{ steps.version.outputs.VERSION }}"
-          echo "View at: https://registry.modelcontextprotocol.io/v0/servers?search=dolphin-mcp-pilot"
+          echo "Published io.github.iflytek/dolphin-mcp-pilot@${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,74 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Publish the manifest to the official MCP Registry.
+  #
+  # `needs: build-and-push` is the point of this job living here rather than in
+  # its own tag-triggered workflow: the registry verifies namespace ownership by
+  # inspecting ghcr.io/iflytek/dolphin-mcp-pilot:<version> for the
+  # io.modelcontextprotocol.server.name label. Publishing before that image is
+  # pushed fails nondeterministically. Two workflows on the same tag gave no
+  # such ordering guarantee.
+  # ---------------------------------------------------------------------------
+  publish-registry:
+    name: Publish server.json to MCP Registry
+    needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required to mint the OIDC token
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # GITHUB_REF_NAME comes from the tag ref, not from user input, so it is
+      # safe to expand here. It is still routed through env for consistency.
+      - name: Derive version from the tag
+        id: version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+      - name: Sync version and OCI tag into server.json
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          jq --arg img "ghcr.io/iflytek/dolphin-mcp-pilot:$VERSION" \
+            '.packages[0].identifier = $img' server.json > server.tmp
+          mv server.tmp server.json
+          cat server.json
+
+      - name: Validate server.json against its declared schema
+        run: |
+          python -m pip install --quiet check-jsonschema
+          SCHEMA=$(jq -r '."$schema"' server.json)
+          echo "Validating against $SCHEMA"
+          python -m check_jsonschema --schemafile "$SCHEMA" server.json
+
+      - name: Install mcp-publisher
+        run: |
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --version
+
+      - name: Authenticate to the MCP Registry via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the registry
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          ./mcp-publisher publish
+          echo "Published io.github.iflytek/dolphin-mcp-pilot@${VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # ---------- Stage 1: build dependencies into a self-contained venv ----------
 FROM python:3.12-slim AS builder
+LABEL io.modelcontextprotocol.server.name="io.github.iflytek/dolphin-mcp-pilot"
 
 ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # ---------- Stage 1: build dependencies into a self-contained venv ----------
 FROM python:3.12-slim AS builder
-LABEL io.modelcontextprotocol.server.name="io.github.iflytek/dolphin-mcp-pilot"
 
 ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -15,7 +14,11 @@ RUN pip install --timeout 300 -r requirements.txt
 # ---------- Stage 2: slim runtime image ----------
 FROM python:3.12-slim
 
-LABEL maintainer="dolphin-mcp-pilot contributors" \
+# io.modelcontextprotocol.server.name proves namespace ownership to the
+# MCP Registry. It must live on the FINAL stage, because only this image
+# is pushed to ghcr.io and inspected during `mcp-publisher publish`.
+LABEL io.modelcontextprotocol.server.name="io.github.iflytek/dolphin-mcp-pilot" \
+      maintainer="dolphin-mcp-pilot contributors" \
       description="dolphin-mcp-pilot - DolphinScheduler MCP Server (open source)" \
       org.opencontainers.image.title="dolphin-mcp-pilot" \
       org.opencontainers.image.description="Production-ready MCP server for Apache DolphinScheduler" \

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.iflytek/dolphin-mcp-pilot",
   "description": "Operate Apache DolphinScheduler from AI agents via MCP — 58 tools for DAG/SQL workflow creation, schedule management, instance control, serial backfills with ordering guarantees, guided troubleshooting with next_action hints, resource operations, and version rollback.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/iflytek/dolphin-mcp-pilot",
     "source": "github"
@@ -10,7 +10,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/iflytek/dolphin-mcp-pilot:0.2.0",
+      "identifier": "ghcr.io/iflytek/dolphin-mcp-pilot:0.3.0",
       "transport": {
         "type": "streamable-http"
       },

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.iflytek/dolphin-mcp-pilot",
-  "description": "Operate Apache DolphinScheduler from AI agents via MCP — 58 tools for DAG/SQL workflow creation, schedule management, instance control, serial backfills with ordering guarantees, guided troubleshooting with next_action hints, resource operations, and version rollback.",
+  "description": "AI agent interface to Apache DolphinScheduler: 58 MCP tools for workflow orchestration & data ops.",
   "version": "0.3.0",
   "repository": {
     "url": "https://github.com/iflytek/dolphin-mcp-pilot",
@@ -12,9 +12,10 @@
       "registryType": "oci",
       "identifier": "ghcr.io/iflytek/dolphin-mcp-pilot:0.3.0",
       "transport": {
-        "type": "streamable-http"
+        "type": "streamable-http",
+        "url": "http://localhost:3000/mcp"
       },
-      "env": [
+      "environmentVariables": [
         {
           "name": "DS_URL",
           "description": "DolphinScheduler API base URL (e.g. http://localhost:12345/dolphinscheduler)",

--- a/server.json
+++ b/server.json
@@ -13,7 +13,7 @@
       "identifier": "ghcr.io/iflytek/dolphin-mcp-pilot:0.3.0",
       "transport": {
         "type": "streamable-http",
-        "url": "http://localhost:3000/mcp"
+        "url": "http://localhost:8001/mcp/"
       },
       "environmentVariables": [
         {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.iflytek/dolphin-mcp-pilot",
+  "description": "Operate Apache DolphinScheduler from AI agents via MCP — 58 tools for DAG/SQL workflow creation, schedule management, instance control, serial backfills with ordering guarantees, guided troubleshooting with next_action hints, resource operations, and version rollback.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/iflytek/dolphin-mcp-pilot",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/iflytek/dolphin-mcp-pilot:0.2.0",
+      "transport": {
+        "type": "streamable-http"
+      },
+      "env": [
+        {
+          "name": "DS_URL",
+          "description": "DolphinScheduler API base URL (e.g. http://localhost:12345/dolphinscheduler)",
+          "isRequired": true
+        },
+        {
+          "name": "DS_TOKEN",
+          "description": "DolphinScheduler API token (leave empty to use DS_USER/DS_PASSWORD instead)"
+        },
+        {
+          "name": "DS_USER",
+          "description": "DolphinScheduler username (alternative to DS_TOKEN)"
+        },
+        {
+          "name": "DS_PASSWORD",
+          "description": "DolphinScheduler password (used with DS_USER)"
+        },
+        {
+          "name": "DS_TENANT_CODE",
+          "description": "Tenant code (default: 'default')"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds **MCP Registry** publishing infrastructure so the server can be discovered on egistry.modelcontextprotocol.io.

- **server.json**: Manifest declaring io.github.iflytek/dolphin-mcp-pilot as an OCI package pointing to ghcr.io/iflytek/dolphin-mcp-pilot:{version} with streamable-http transport. Documents all env vars (DS_URL required, DS_TOKEN or DS_USER/DS_PASSWORD, DS_TENANT_CODE).
- **publish-registry.yml**: Workflow that logs in via GitHub token (granting io.github.iflytek/* namespace), updates version/tag in server.json, and calls mcp-publisher publish. Triggers on tag push (*.*.*) or manual dispatch.

## Why

The [official MCP Registry](https://registry.modelcontextprotocol.io) is now the canonical discovery mechanism 鈥?the [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) README redirects to it, and community lists like [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers/pull/11930) supplement rather than replace it. Without a registry entry, AI agents and MCP clients won't auto-discover this server.

## Prerequisites (already met)

- **Namespace ownership**: GitHub org login grants io.github.iflytek/*
- **Package ownership**: 40 published versions at ghcr.io/iflytek/dolphin-mcp-pilot (public visibility)
- **Workflow auth**: secrets.GITHUB_TOKEN has sufficient scope for mcp-publisher login github --token

## First publish

The workflow will run after the next tag push (e.g., 0.2.1). It can also be triggered manually via Actions 鈫?Publish to MCP Registry 鈫?Run workflow 鈫?enter version .2.1.

Once published, the server will appear at:
**https://registry.modelcontextprotocol.io/servers/io.github.iflytek/dolphin-mcp-pilot**

## Related

- Community list PR: https://github.com/punkpeye/awesome-mcp-servers/pull/11930 (already submitted)
- Official Apache DolphinScheduler discussion: https://github.com/apache/dolphinscheduler/discussions/18547 (already posted)