### PR TITLE
test(e2e): cover read-only MCP modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A production-ready MCP server for Apache DolphinScheduler.
 
 **dolphin-mcp-pilot** exposes **53+ tools** for projects, workflows, DAG creation, schedules, instances, resources, logs, monitoring and raw API passthrough — designed for AI agents that need to operate DolphinScheduler beyond basic read-only usage.
 
+> **Compatibility target:** DolphinScheduler 3.x broadly. Automated Docker Compose E2E currently
+> runs against the 3.4.x standalone image; monitor endpoint differences inside the 3.2 line are
+> covered by fallback behavior.
+
 ## 🎯 Why this project?
 
 Most public DolphinScheduler MCP servers only cover basic read/list/start/stop scenarios.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,25 @@ A production-ready MCP server for Apache DolphinScheduler.
 
 **dolphin-mcp-pilot** exposes **53+ tools** for projects, workflows, DAG creation, schedules, instances, resources, logs, monitoring and raw API passthrough — designed for AI agents that need to operate DolphinScheduler beyond basic read-only usage.
 
-> **Compatibility target:** DolphinScheduler 3.x broadly. Automated Docker Compose E2E currently
-> runs against the 3.4.x standalone image; monitor endpoint differences inside the 3.2 line are
-> covered by fallback behavior.
+## 🔧 Compatibility
+
+**dolphin-mcp-pilot** targets Apache DolphinScheduler **3.x**. The automated Docker Compose E2E
+suite runs against the 3.4.x standalone image on every CI run; the other lines are verified against
+the matching upstream API controller source and covered by runtime fallbacks where endpoints differ.
+
+| DolphinScheduler (backend engine) | Status | How it's verified |
+|---|---|---|
+| 3.4.x standalone | ✅ CI-validated | Automated Docker Compose E2E, default `DS_VERSION=3.4.2` |
+| 3.2.2 – 3.3.x / `dev` | ✔️ Source-verified | Monitor listing uses the enum route `/monitor/{nodeType}`; other read-only routes checked against upstream controllers and pinned by unit tests |
+| 3.0.x – 3.2.1 | ✔️ Source-verified | Legacy monitor routes (`/monitor/masters`, `/monitor/workers`) reached via automatic 404 fallback in `_list_servers` |
+
+**Legend** — ✅ **CI-validated**: exercised on every CI run against a live DS image · ✔️ **Source-verified**:
+endpoint paths checked against the matching upstream `*Controller` source and locked by unit tests, but not
+yet part of the CI image matrix.
+
+> **Note:** the `process-*` → `workflow-*` REST path rename that landed in the DS 3.3 line (e.g.
+> `workflow-definition`, `workflow-instances`) affects the workflow/instance tools and is tracked
+> separately in [#42](https://github.com/iflytek/dolphin-mcp-pilot/issues/42).
 
 ## 🎯 Why this project?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,9 @@ Apache DolphinScheduler 的生产级 MCP 服务器。
 
 **dolphin-mcp-pilot** 提供 **53+ 工具**，覆盖项目管理、工作流、DAG 创建、调度、实例、资源、日志、监控以及原始 API 透传 —— 专为需要超越只读操作的 AI Agent 设计。
 
+> **兼容目标：**覆盖 DolphinScheduler 3.x。自动化 Docker Compose E2E 当前固定使用
+> 3.4.x standalone 镜像；3.2 系列内部的监控接口差异已通过兼容回退处理。
+
 ## 🎯 为什么需要这个项目？
 
 目前公开的 DolphinScheduler MCP 服务器大多只覆盖基础的读/列/启停场景。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,8 +14,24 @@ Apache DolphinScheduler 的生产级 MCP 服务器。
 
 **dolphin-mcp-pilot** 提供 **53+ 工具**，覆盖项目管理、工作流、DAG 创建、调度、实例、资源、日志、监控以及原始 API 透传 —— 专为需要超越只读操作的 AI Agent 设计。
 
-> **兼容目标：**覆盖 DolphinScheduler 3.x。自动化 Docker Compose E2E 当前固定使用
-> 3.4.x standalone 镜像；3.2 系列内部的监控接口差异已通过兼容回退处理。
+## 🔧 兼容性
+
+**dolphin-mcp-pilot** 面向 Apache DolphinScheduler **3.x**。自动化 Docker Compose E2E 每次 CI 都会针对
+3.4.x standalone 镜像运行；其余版本则对照上游对应的 API Controller 源码核对，并在接口存在差异处以运行时
+兼容回退覆盖。
+
+| DolphinScheduler（后端引擎） | 状态 | 验证方式 |
+|---|---|---|
+| 3.4.x standalone | ✅ CI 实测 | 自动化 Docker Compose E2E，默认 `DS_VERSION=3.4.2` |
+| 3.2.2 – 3.3.x / `dev` | ✔️ 源码核对 | 监控列表走枚举路由 `/monitor/{nodeType}`；其余只读路由对照上游 Controller 核对并有单测锁定 |
+| 3.0.x – 3.2.1 | ✔️ 源码核对 | 旧版监控路由（`/monitor/masters`、`/monitor/workers`）通过 `_list_servers` 中的 404 自动回退访问 |
+
+**图例** —— ✅ **CI 实测**：每次 CI 都会针对真实 DS 镜像运行 · ✔️ **源码核对**：接口路径已对照上游对应
+`*Controller` 源码核对并有单测锁定，但尚未纳入 CI 镜像矩阵。
+
+> **说明：** DS 3.3 系列引入的 `process-*` → `workflow-*` REST 路径重命名（如
+> `workflow-definition`、`workflow-instances`）影响工作流/实例类工具，已在
+> [#42](https://github.com/iflytek/dolphin-mcp-pilot/issues/42) 中单独跟踪。
 
 ## 🎯 为什么需要这个项目？
 

--- a/dolphin_mcp_pilot/tools/monitor.py
+++ b/dolphin_mcp_pilot/tools/monitor.py
@@ -27,13 +27,13 @@ def register_monitor_tools(mcp: MCPServer):
     @mcp.tool()
     def ds_monitor_masters() -> list:
         """Check DS master node status (verify scheduler is alive)."""
-        result = ds_get("/monitor/masters")
+        result = ds_get("/monitor/MASTER")
         require_ok(result, "get master status")
         return result.get("data", []) or []
 
     @mcp.tool()
     def ds_monitor_workers() -> list:
         """Check DS worker node status (verify task executors are alive)."""
-        result = ds_get("/monitor/workers")
+        result = ds_get("/monitor/WORKER")
         require_ok(result, "get worker status")
         return result.get("data", []) or []

--- a/dolphin_mcp_pilot/tools/monitor.py
+++ b/dolphin_mcp_pilot/tools/monitor.py
@@ -15,10 +15,27 @@
 
 """Monitoring tools."""
 
+import urllib.error
+
 from mcp.server.mcpserver import MCPServer
 
 from ..client import ds_get
 from ..utils import require_ok
+
+
+def _list_servers(node_type: str) -> list:
+    """List registry nodes of one type, across DolphinScheduler lines.
+
+    DS >= 3.2.2 serves ``/monitor/{RegistryNodeType}`` (``MASTER`` / ``WORKER``);
+    3.2.1 and older only expose ``/monitor/masters`` and ``/monitor/workers``.
+    Try the current path first and fall back when the server does not know it.
+    """
+    try:
+        result = ds_get(f"/monitor/{node_type}")
+    except urllib.error.HTTPError:
+        result = ds_get(f"/monitor/{node_type.lower()}s")
+    require_ok(result, f"get {node_type.lower()} status")
+    return result.get("data", []) or []
 
 
 def register_monitor_tools(mcp: MCPServer):
@@ -27,13 +44,9 @@ def register_monitor_tools(mcp: MCPServer):
     @mcp.tool()
     def ds_monitor_masters() -> list:
         """Check DS master node status (verify scheduler is alive)."""
-        result = ds_get("/monitor/MASTER")
-        require_ok(result, "get master status")
-        return result.get("data", []) or []
+        return _list_servers("MASTER")
 
     @mcp.tool()
     def ds_monitor_workers() -> list:
         """Check DS worker node status (verify task executors are alive)."""
-        result = ds_get("/monitor/WORKER")
-        require_ok(result, "get worker status")
-        return result.get("data", []) or []
+        return _list_servers("WORKER")

--- a/dolphin_mcp_pilot/tools/user.py
+++ b/dolphin_mcp_pilot/tools/user.py
@@ -26,7 +26,9 @@ def register_user_tools(mcp: MCPServer):
 
     @mcp.tool()
     def ds_list_users() -> list:
-        """List all DS users (useful for debugging workflow user_id foreign key issues)."""
+        """List all DS users, administrators included (debug user_id foreign keys)."""
+        # /users/list returns general users only, so an admin-owned workflow's
+        # user_id would be missing from the result; /users/list-all includes them.
         result = ds_get("/users/list-all")
         require_ok(result, "list users")
         return [

--- a/dolphin_mcp_pilot/tools/user.py
+++ b/dolphin_mcp_pilot/tools/user.py
@@ -27,7 +27,7 @@ def register_user_tools(mcp: MCPServer):
     @mcp.tool()
     def ds_list_users() -> list:
         """List all DS users (useful for debugging workflow user_id foreign key issues)."""
-        result = ds_get("/users/list")
+        result = ds_get("/users/list-all")
         require_ok(result, "list users")
         return [
             {

--- a/tests/e2e/_assertions.py
+++ b/tests/e2e/_assertions.py
@@ -1,0 +1,29 @@
+"""Assertions shared by MCP end-to-end tool tests."""
+
+import json
+
+
+def parse_successful_tool_text(response):
+    """Validate the MCP wire envelope and decode its first text item."""
+    assert response.get("jsonrpc") == "2.0", f"invalid JSON-RPC envelope: {response}"
+    assert "error" not in response, f"tool call returned JSON-RPC error: {response}"
+
+    result = response.get("result")
+    assert isinstance(result, dict), f"tool result must be an object: {response}"
+    assert (
+        result.get("isError") is not True
+    ), f"tool call returned MCP error: {response}"
+
+    content = result.get("content")
+    assert (
+        isinstance(content, list) and content
+    ), f"tool returned no content: {response}"
+    first = content[0]
+    assert first.get("type") == "text", f"expected text content: {first}"
+
+    text = first.get("text")
+    assert isinstance(text, str), f"text content must be a string: {first}"
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"tool text is not valid JSON: {text!r}") from exc

--- a/tests/e2e/_assertions.py
+++ b/tests/e2e/_assertions.py
@@ -3,8 +3,8 @@
 import json
 
 
-def parse_successful_tool_text(response):
-    """Validate the MCP wire envelope and decode its first text item."""
+def parse_successful_tool_items(response):
+    """Validate the MCP wire envelope and decode every text item."""
     assert response.get("jsonrpc") == "2.0", f"invalid JSON-RPC envelope: {response}"
     assert "error" not in response, f"tool call returned JSON-RPC error: {response}"
 
@@ -14,16 +14,17 @@ def parse_successful_tool_text(response):
         result.get("isError") is not True
     ), f"tool call returned MCP error: {response}"
 
+    assert result.get("resultType") == "complete", f"incomplete tool result: {result}"
     content = result.get("content")
-    assert (
-        isinstance(content, list) and content
-    ), f"tool returned no content: {response}"
-    first = content[0]
-    assert first.get("type") == "text", f"expected text content: {first}"
+    assert isinstance(content, list), f"tool content must be a list: {response}"
 
-    text = first.get("text")
-    assert isinstance(text, str), f"text content must be a string: {first}"
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise AssertionError(f"tool text is not valid JSON: {text!r}") from exc
+    items = []
+    for item in content:
+        assert item.get("type") == "text", f"expected text content: {item}"
+        item_text = item.get("text")
+        assert isinstance(item_text, str), f"text content must be a string: {item}"
+        try:
+            items.append(json.loads(item_text))
+        except json.JSONDecodeError as exc:
+            raise AssertionError(f"tool text is not valid JSON: {item_text!r}") from exc
+    return items

--- a/tests/e2e/test_00_tool_inventory.py
+++ b/tests/e2e/test_00_tool_inventory.py
@@ -1,0 +1,72 @@
+"""MCP discovery coverage for the complete public tool inventory."""
+
+EXPECTED_TOOL_NAMES = {
+    "ds_clone_workflow",
+    "ds_complement_data",
+    "ds_create_dag_workflow",
+    "ds_create_folder",
+    "ds_create_project",
+    "ds_create_workflow",
+    "ds_delete_process_instance",
+    "ds_delete_project",
+    "ds_delete_resource",
+    "ds_delete_schedule",
+    "ds_delete_workflow",
+    "ds_download_resource",
+    "ds_force_task_success",
+    "ds_get_latest_failure_log",
+    "ds_get_resource_by_name",
+    "ds_get_task_detail",
+    "ds_get_task_log",
+    "ds_get_workflow",
+    "ds_help",
+    "ds_list_datasources",
+    "ds_list_process_instances",
+    "ds_list_projects",
+    "ds_list_resources",
+    "ds_list_schedules",
+    "ds_list_task_instances",
+    "ds_list_tenants",
+    "ds_list_users",
+    "ds_list_workflow_versions",
+    "ds_list_workflows",
+    "ds_modify_workflow_dag",
+    "ds_monitor_masters",
+    "ds_monitor_workers",
+    "ds_offline_schedule",
+    "ds_online_create_file",
+    "ds_online_schedule",
+    "ds_pause_process_instance",
+    "ds_put_lite",
+    "ds_raw_delete",
+    "ds_raw_get",
+    "ds_raw_post",
+    "ds_raw_put",
+    "ds_release_workflow",
+    "ds_rename_project",
+    "ds_rename_resource",
+    "ds_rerun_from_failure",
+    "ds_rerun_process_instance",
+    "ds_resume_process_instance",
+    "ds_rollback_workflow_version",
+    "ds_run_workflow",
+    "ds_set_schedule",
+    "ds_skip_task",
+    "ds_stop_process_instance",
+    "ds_test_connection",
+    "ds_update_resource_content",
+    "ds_update_schedule_cron",
+    "ds_update_task_param",
+    "ds_update_workflow",
+    "ds_upload_file",
+    "ds_view_resource",
+}
+
+
+def test_complete_tool_inventory_is_discoverable(mcp_client):
+    """Catch missing, renamed, or duplicate tools at the MCP boundary."""
+    tools = mcp_client.tools_list()
+    names = [tool["name"] for tool in tools]
+
+    assert len(names) == len(set(names)), "tools/list returned duplicate tool names"
+    assert set(names) == EXPECTED_TOOL_NAMES

--- a/tests/e2e/test_00_tool_inventory.py
+++ b/tests/e2e/test_00_tool_inventory.py
@@ -37,7 +37,6 @@ EXPECTED_TOOL_NAMES = {
     "ds_online_create_file",
     "ds_online_schedule",
     "ds_pause_process_instance",
-    "ds_put_lite",
     "ds_raw_delete",
     "ds_raw_get",
     "ds_raw_post",

--- a/tests/e2e/test_04_datasource.py
+++ b/tests/e2e/test_04_datasource.py
@@ -1,12 +1,11 @@
 """Read-only data source end-to-end coverage."""
 
-from ._assertions import parse_successful_tool_text
+from ._assertions import parse_successful_tool_items
 
 
 def test_list_datasources_returns_json_list(mcp_client):
     response = mcp_client.call_tool("ds_list_datasources", {})
 
-    payload = parse_successful_tool_text(response)
-    assert isinstance(payload, list), f"expected data source list, got: {payload}"
-    for datasource in payload:
+    items = parse_successful_tool_items(response)
+    for datasource in items:
         assert {"id", "name", "type"} <= datasource.keys()

--- a/tests/e2e/test_04_datasource.py
+++ b/tests/e2e/test_04_datasource.py
@@ -1,0 +1,12 @@
+"""Read-only data source end-to-end coverage."""
+
+from ._assertions import parse_successful_tool_text
+
+
+def test_list_datasources_returns_json_list(mcp_client):
+    response = mcp_client.call_tool("ds_list_datasources", {})
+
+    payload = parse_successful_tool_text(response)
+    assert isinstance(payload, list), f"expected data source list, got: {payload}"
+    for datasource in payload:
+        assert {"id", "name", "type"} <= datasource.keys()

--- a/tests/e2e/test_07_monitor.py
+++ b/tests/e2e/test_07_monitor.py
@@ -1,17 +1,17 @@
 """Read-only cluster monitoring end-to-end coverage."""
 
-from ._assertions import parse_successful_tool_text
+from ._assertions import parse_successful_tool_items
 
 
 def test_monitor_masters_returns_json_list(mcp_client):
     response = mcp_client.call_tool("ds_monitor_masters", {})
 
-    payload = parse_successful_tool_text(response)
-    assert isinstance(payload, list), f"expected master list, got: {payload}"
+    items = parse_successful_tool_items(response)
+    assert items, "expected at least one DolphinScheduler master"
 
 
 def test_monitor_workers_returns_json_list(mcp_client):
     response = mcp_client.call_tool("ds_monitor_workers", {})
 
-    payload = parse_successful_tool_text(response)
-    assert isinstance(payload, list), f"expected worker list, got: {payload}"
+    items = parse_successful_tool_items(response)
+    assert items, "expected at least one DolphinScheduler worker"

--- a/tests/e2e/test_07_monitor.py
+++ b/tests/e2e/test_07_monitor.py
@@ -1,0 +1,17 @@
+"""Read-only cluster monitoring end-to-end coverage."""
+
+from ._assertions import parse_successful_tool_text
+
+
+def test_monitor_masters_returns_json_list(mcp_client):
+    response = mcp_client.call_tool("ds_monitor_masters", {})
+
+    payload = parse_successful_tool_text(response)
+    assert isinstance(payload, list), f"expected master list, got: {payload}"
+
+
+def test_monitor_workers_returns_json_list(mcp_client):
+    response = mcp_client.call_tool("ds_monitor_workers", {})
+
+    payload = parse_successful_tool_text(response)
+    assert isinstance(payload, list), f"expected worker list, got: {payload}"

--- a/tests/e2e/test_10_user.py
+++ b/tests/e2e/test_10_user.py
@@ -1,0 +1,24 @@
+"""Read-only user and tenant end-to-end coverage."""
+
+from ._assertions import parse_successful_tool_text
+
+
+def test_list_users_includes_authenticated_user(mcp_client, admin_credentials):
+    response = mcp_client.call_tool("ds_list_users", {})
+
+    payload = parse_successful_tool_text(response)
+    assert isinstance(payload, list), f"expected user list, got: {payload}"
+    assert any(
+        user.get("userName") == admin_credentials["user"] for user in payload
+    ), f"authenticated user missing from response: {payload}"
+    for user in payload:
+        assert {"id", "userName", "tenantId"} <= user.keys()
+
+
+def test_list_tenants_returns_json_list(mcp_client):
+    response = mcp_client.call_tool("ds_list_tenants", {})
+
+    payload = parse_successful_tool_text(response)
+    assert isinstance(payload, list), f"expected tenant list, got: {payload}"
+    for tenant in payload:
+        assert {"id", "tenantCode", "description"} <= tenant.keys()

--- a/tests/e2e/test_10_user.py
+++ b/tests/e2e/test_10_user.py
@@ -1,24 +1,23 @@
 """Read-only user and tenant end-to-end coverage."""
 
-from ._assertions import parse_successful_tool_text
+from ._assertions import parse_successful_tool_items
 
 
 def test_list_users_includes_authenticated_user(mcp_client, admin_credentials):
     response = mcp_client.call_tool("ds_list_users", {})
 
-    payload = parse_successful_tool_text(response)
-    assert isinstance(payload, list), f"expected user list, got: {payload}"
+    items = parse_successful_tool_items(response)
     assert any(
-        user.get("userName") == admin_credentials["user"] for user in payload
-    ), f"authenticated user missing from response: {payload}"
-    for user in payload:
+        user.get("userName") == admin_credentials["user"] for user in items
+    ), f"authenticated user missing from response: {items}"
+    for user in items:
         assert {"id", "userName", "tenantId"} <= user.keys()
 
 
 def test_list_tenants_returns_json_list(mcp_client):
     response = mcp_client.call_tool("ds_list_tenants", {})
 
-    payload = parse_successful_tool_text(response)
-    assert isinstance(payload, list), f"expected tenant list, got: {payload}"
-    for tenant in payload:
+    items = parse_successful_tool_items(response)
+    assert items, "expected at least one DolphinScheduler tenant"
+    for tenant in items:
         assert {"id", "tenantCode", "description"} <= tenant.keys()

--- a/tests/test_read_only_tools.py
+++ b/tests/test_read_only_tools.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import urllib.error
 from unittest.mock import patch
 
 from mcp.client import Client
@@ -30,6 +31,26 @@ def test_monitor_tools_use_registry_enum_paths(mock_ds_get):
     assert workers == [{"host": "127.0.0.1"}]
     assert mock_ds_get.call_args_list[0].args == ("/monitor/MASTER",)
     assert mock_ds_get.call_args_list[1].args == ("/monitor/WORKER",)
+
+
+@patch("dolphin_mcp_pilot.tools.monitor.ds_get")
+def test_monitor_tools_fall_back_to_legacy_paths(mock_ds_get):
+    """DS <= 3.2.1 has no /monitor/{nodeType}; the legacy plural path must be tried."""
+
+    def respond(path):
+        if path == "/monitor/MASTER":
+            raise urllib.error.HTTPError(path, 404, "Not Found", None, None)
+        return {"code": 0, "data": [{"host": "127.0.0.1"}]}
+
+    mock_ds_get.side_effect = respond
+
+    masters = _decoded_text_items(asyncio.run(_call_tool("ds_monitor_masters")))
+
+    assert masters == [{"host": "127.0.0.1"}]
+    assert [call.args[0] for call in mock_ds_get.call_args_list] == [
+        "/monitor/MASTER",
+        "/monitor/masters",
+    ]
 
 
 @patch("dolphin_mcp_pilot.tools.user.ds_get")

--- a/tests/test_read_only_tools.py
+++ b/tests/test_read_only_tools.py
@@ -1,0 +1,45 @@
+"""Unit coverage for read-only tool endpoint contracts."""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+from mcp.client import Client
+
+from dolphin_mcp_pilot import mcp
+
+
+async def _call_tool(name):
+    async with Client(mcp) as client:
+        return await client.call_tool(name, {})
+
+
+def _decoded_text_items(result):
+    assert result.is_error is False
+    return [json.loads(item.text) for item in result.content if item.type == "text"]
+
+
+@patch("dolphin_mcp_pilot.tools.monitor.ds_get")
+def test_monitor_tools_use_registry_enum_paths(mock_ds_get):
+    mock_ds_get.return_value = {"code": 0, "data": [{"host": "127.0.0.1"}]}
+
+    masters = _decoded_text_items(asyncio.run(_call_tool("ds_monitor_masters")))
+    workers = _decoded_text_items(asyncio.run(_call_tool("ds_monitor_workers")))
+
+    assert masters == [{"host": "127.0.0.1"}]
+    assert workers == [{"host": "127.0.0.1"}]
+    assert mock_ds_get.call_args_list[0].args == ("/monitor/MASTER",)
+    assert mock_ds_get.call_args_list[1].args == ("/monitor/WORKER",)
+
+
+@patch("dolphin_mcp_pilot.tools.user.ds_get")
+def test_list_users_includes_administrators(mock_ds_get):
+    mock_ds_get.return_value = {
+        "code": 0,
+        "data": [{"id": 1, "userName": "admin", "tenantId": -1}],
+    }
+
+    users = _decoded_text_items(asyncio.run(_call_tool("ds_list_users")))
+
+    assert users == [{"id": 1, "userName": "admin", "tenantId": -1}]
+    mock_ds_get.assert_called_once_with("/users/list-all")


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Refs #23 (incremental coverage; intentionally does not close the issue).

## Summary

- add an exact MCP tools/list inventory assertion for all 58 public tools
- add live read-only coverage for datasource, master/worker monitoring, users, and tenants
- validate the JSON-RPC envelope, MCP error flag, result type, text content, and JSON payload for every new tool call
- handle MCP 2.0 list serialization correctly, including an empty list as empty content and list items as separate text blocks
- fix DolphinScheduler 3.4 monitor calls to use the MASTER / WORKER registry enum paths
- make ds_list_users honor its all-users contract via /users/list-all, including administrators
- keep the e2e slice side-effect free so it is safe for repeatable CI runs

## Checks

- [x] ruff check dolphin_mcp_pilot tests
- [x] ruff format --check dolphin_mcp_pilot tests
- [x] python -m unittest discover -s tests -p 'test_*.py'
- [x] bandit -r dolphin_mcp_pilot -ll
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to iflytek/dolphin-mcp-pilot
- [x] No hardcoded secrets, internal IPs, or plaintext tokens
- [x] 25 non-e2e pytest tests passed
- [x] all 24 e2e tests collected successfully
- [x] live Docker-compose e2e passed against DolphinScheduler 3.4.2
- [x] GitHub CI, security scan, package build, MCP 1.29/2.0 compatibility, DCO, and CLA passed

## Special notes for reviewers

This is the first read-only slice of #23. The issue should remain open for the stateful instance, resource, schedule, workflow, workflow-advanced, and raw API suites.

The first e2e run exposed three real contract assumptions: ds_put_lite is an internal helper rather than a public tool, DolphinScheduler 3.4 expects registry enum values in the monitor path, and the official MCP 2.0 client serializes returned lists as zero or more text blocks. The follow-up commit fixes each issue and adds focused unit coverage for the endpoint contracts.

The help tool already has three live calls in test_01_smoke.py, so this PR does not add a redundant test_14_help.py.
