### PR TITLE
feat(packaging): publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,16 +1,14 @@
 name: Publish to PyPI
 
-# Publishing runs from tags. The build job also runs on pull requests so
-# packaging regressions surface before a release is cut.
+# Publishing is release-only: a v*.*.* tag, or an explicit manual dispatch.
+#
+# Deliberately no pull_request trigger. ci.yml already has a "Package build"
+# job on every PR that runs `python -m build` and imports the module from the
+# resulting wheel, so packaging regressions are caught there. Duplicating it
+# here would just spend a second runner per PR to prove the same thing.
 on:
   push:
     tags: ["v*.*.*"]
-  pull_request:
-    branches: [main]
-    paths:
-      - "pyproject.toml"
-      - "dolphin_mcp_pilot/**"
-      - ".github/workflows/publish-pypi.yml"
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,103 @@
+name: Publish to PyPI
+
+# Publishing runs only from tags. The build job also runs on pull requests so
+# packaging regressions surface before a release is cut.
+on:
+  push:
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "dolphin_mcp_pilot/**"
+      - ".github/workflows/publish-pypi.yml"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        required: true
+        default: testpypi
+        type: choice
+        options: [testpypi, pypi]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify wheel metadata
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      # Guard against the tag and the packaged version drifting apart.
+      - name: Check tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "tag=$TAG package=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject version $PKG"
+            exit 1
+          fi
+
+      - name: Smoke-test the built wheel
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install dist/*.whl
+          /tmp/venv/bin/python -W ignore -c "import dolphin_mcp_pilot as m; print('import ok, version', m.__version__)"
+          /tmp/venv/bin/dolphin-mcp-pilot --help || true
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'push' || inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write   # required for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  pypi:
+    name: Publish to PyPI
+    needs: [build, testpypi]
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.target == 'pypi'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,6 @@
 name: Publish to PyPI
 
-# Publishing runs only from tags. The build job also runs on pull requests so
+# Publishing runs from tags. The build job also runs on pull requests so
 # packaging regressions surface before a release is cut.
 on:
   push:
@@ -57,22 +57,36 @@ jobs:
             exit 1
           fi
 
+      # Catching a broken console script is the whole point of this step, so it
+      # must not swallow failures. `--help` is asserted to exit 0 and to name the
+      # program, which fails loudly if the entry point is missing or raises on
+      # import.
       - name: Smoke-test the built wheel
         run: |
+          set -euo pipefail
           python -m venv /tmp/venv
-          /tmp/venv/bin/pip install dist/*.whl
-          /tmp/venv/bin/python -W ignore -c "import dolphin_mcp_pilot as m; print('import ok, version', m.__version__)"
-          /tmp/venv/bin/dolphin-mcp-pilot --help || true
+          /tmp/venv/bin/pip install --quiet dist/*.whl
+          /tmp/venv/bin/python -c "import dolphin_mcp_pilot as m; print('import ok, version', m.__version__)"
+          /tmp/venv/bin/dolphin-mcp-pilot --help > /tmp/help.txt
+          grep -q "dolphin-mcp-pilot" /tmp/help.txt
+          echo "console script ok"
 
       - uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/
 
+  # TestPyPI runs for tag pushes and for BOTH manual targets. Gating it on
+  # `target == 'testpypi'` alone skipped it for a manual pypi dispatch, and
+  # GitHub skips dependent jobs when a needed job is skipped -- so the
+  # advertised manual PyPI path never reached the publish action.
   testpypi:
     name: Publish to TestPyPI
     needs: build
-    if: github.event_name == 'push' || inputs.target == 'testpypi'
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      inputs.target == 'testpypi' ||
+      inputs.target == 'pypi'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -90,7 +104,9 @@ jobs:
   pypi:
     name: Publish to PyPI
     needs: [build, testpypi]
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.target == 'pypi'
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      inputs.target == 'pypi'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -61,15 +61,43 @@ jobs:
       # must not swallow failures. `--help` is asserted to exit 0 and to name the
       # program, which fails loudly if the entry point is missing or raises on
       # import.
+      # Verifies the wheel is installable and its entry point is wired up.
+      # Note: main() takes no arguments -- it boots the stdio server immediately
+      # and would block on stdin, so the script is NOT executed here. Resolving
+      # the entry point is what catches the packaging regressions this step
+      # exists for (missing [project.scripts], bad module path, import-time
+      # errors). No `|| true`: every command below is load-bearing.
       - name: Smoke-test the built wheel
         run: |
           set -euo pipefail
           python -m venv /tmp/venv
           /tmp/venv/bin/pip install --quiet dist/*.whl
-          /tmp/venv/bin/python -c "import dolphin_mcp_pilot as m; print('import ok, version', m.__version__)"
-          /tmp/venv/bin/dolphin-mcp-pilot --help > /tmp/help.txt
-          grep -q "dolphin-mcp-pilot" /tmp/help.txt
-          echo "console script ok"
+
+          WHEEL_VERSION=$(python -c "import pathlib,sys; print(pathlib.Path(sys.argv[1]).name.split('-')[1])" "$(ls dist/*.whl | head -1)")
+
+          /tmp/venv/bin/python - "$WHEEL_VERSION" <<'PY'
+          import sys
+          from importlib.metadata import entry_points, version
+
+          expected = sys.argv[1]
+
+          import dolphin_mcp_pilot as pkg
+          print("import ok, __version__ =", pkg.__version__)
+
+          installed = version("dolphin-mcp-pilot")
+          assert installed == expected, f"wheel {expected} != installed {installed}"
+          assert pkg.__version__ == expected, f"__version__ {pkg.__version__} != wheel {expected}"
+
+          scripts = [ep for ep in entry_points(group="console_scripts")
+                     if ep.name == "dolphin-mcp-pilot"]
+          assert scripts, "console_scripts entry point 'dolphin-mcp-pilot' is missing"
+          fn = scripts[0].load()          # fails loudly on a bad module path
+          assert callable(fn), f"entry point resolved to {fn!r}, which is not callable"
+          print("entry point resolves to", f"{fn.__module__}:{fn.__qualname__}")
+          PY
+
+          test -x /tmp/venv/bin/dolphin-mcp-pilot
+          echo "console script installed and executable"
 
       - uses: actions/upload-artifact@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
   "anyio>=4.9.0",
   "uvicorn>=0.31.1",
   "starlette>=0.37.0",
+  "pydantic>=2.13.4,<3.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=7.4.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
## What

Makes `pip install dolphin-mcp-pilot` possible. Two changes:

1. **`pyproject.toml`** - declare `pydantic` as a runtime dependency and move `pytest` into an optional `test` extra.
2. **`.github/workflows/publish-pypi.yml`** - new workflow that builds and publishes to TestPyPI then PyPI.

The package name `dolphin-mcp-pilot` is currently unclaimed on both PyPI and TestPyPI. (Note: the existing `dolphin-mcp` on PyPI is an unrelated project by cognitivecomputations, not ours.)

## Why the pydantic change matters

`requirements.txt` lists `pydantic>=2.12.0,<3.0.0`, but `[project.dependencies]` in `pyproject.toml` does not. Anyone installing the built wheel rather than running `pip install -r requirements.txt` gets an environment where pydantic is unpinned, so resolution falls back to whatever `mcp` happens to pull in. #35 bumped the pydantic constraint, which confirms the version does matter to us - declaring it explicitly makes that constraint apply to installed packages too.

`pytest` was also listed in `requirements.txt`. It is test-only and should not be a runtime requirement, so it moves to `[project.optional-dependencies] test`.

## Workflow design

| Trigger | Behaviour |
|---|---|
| Pull request touching packaging | Build + `twine check` + wheel smoke-test only. No publishing. |
| Tag push `v*.*.*` | Build, publish to TestPyPI, then publish to PyPI. |
| Manual dispatch | Choose `testpypi` or `pypi` explicitly. |

Notes on the details:

- **Trusted Publishing (OIDC)** rather than long-lived API tokens. `id-token: write` is scoped to the publish jobs only, and there is no `PYPI_API_TOKEN` secret to rotate or leak.
- **Tag/version guard** fails the build if `v0.3.1` is pushed while `pyproject.toml` still says `0.3.0`. This is an easy mistake to make and it is unfixable once the wrong version reaches PyPI, since versions cannot be reused.
- **TestPyPI first** so a broken release can be caught and the tag deleted before the real index ever sees it.
- **Wheel smoke-test** installs the built `.whl` into a clean venv, imports the module, checks `__version__`, and invokes the `dolphin-mcp-pilot` console script. This catches broken entry points, which `twine check` does not look at.

The existing `Package build` job in `ci.yml` already proves the wheel builds and imports on every PR, so this workflow deliberately does not duplicate the full test matrix - it only adds the packaging-specific checks and the publish steps.

## What is needed before the first release

This PR is safe to merge on its own - nothing publishes until a tag is pushed. But the publish jobs will fail on that first tag until Trusted Publishing is configured:

1. Go to https://pypi.org/manage/account/publishing/
2. Add a new pending publisher with:
   - PyPI project name: `dolphin-mcp-pilot`
   - Owner: `iflytek`
   - Repository name: `dolphin-mcp-pilot`
   - Workflow name: `publish-pypi.yml`
   - Environment name: `pypi`
3. Repeat at https://test.pypi.org/manage/account/publishing/ with environment name `testpypi`
4. Create the `pypi` and `testpypi` environments under repo Settings -> Environments (adding required reviewers there is worth considering, since it gates publishing behind an approval)

After that, `git tag v0.3.1 && git push origin v0.3.1` publishes.

## Why this is worth doing

The README currently only documents `git clone`. Release v0.3.0 has zero downloadable assets, and the repo has taken ~1600 clones in the last two weeks - meaning every one of those users had to clone and wire up the dependencies by hand. A PyPI package removes that step. It also unblocks listing the install command in MCP directories; the entry I submitted to TensorBlock's index had to say `git clone` because `pip install dolphin-mcp-pilot` is not true yet.