### PR TITLE
docs: add "小海豚" to README for Chinese search discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 </div>
 
-A production-ready MCP server for Apache DolphinScheduler.
+A production-ready MCP server for Apache DolphinScheduler (小海豚).
 
 **dolphin-mcp-pilot** exposes **53+ tools** for projects, workflows, DAG creation, schedules, instances, resources, logs, monitoring and raw API passthrough — designed for AI agents that need to operate DolphinScheduler beyond basic read-only usage.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 </div>
 
-Apache DolphinScheduler 的生产级 MCP 服务器。
+Apache DolphinScheduler（小海豚调度系统）的生产级 MCP 服务器。
 
 **dolphin-mcp-pilot** 提供 **53+ 工具**，覆盖项目管理、工作流、DAG 创建、调度、实例、资源、日志、监控以及原始 API 透传 —— 专为需要超越只读操作的 AI Agent 设计。
 


### PR DESCRIPTION
## Problem

Users searching "小海豚 mcp" cannot find this project because the nickname never appeared in the repository.

Testing showed:
- **MCP Registry search "小海豚 mcp"**: 0 results
- **GitHub search "小海豚 mcp"**: not in top 10
- **GitHub search "dolphinscheduler mcp"**: #2 ✅ (English works)

## Solution

Add "小海豚" to both README files so Chinese users can discover the project through:
- GitHub search
- Google search
- Chinese AI assistants (Kimi, 豆包, etc.)

## Changes

- `README.md`: "Apache DolphinScheduler" → "Apache DolphinScheduler (小海豚)"
- `README.zh-CN.md`: "Apache DolphinScheduler" → "Apache DolphinScheduler（小海豚调度系统）"

## Impact

Zero breaking changes. Pure documentation improvement for Chinese-speaking users.
